### PR TITLE
Backup local to checkpoint compatible location on download

### DIFF
--- a/cloudpoint_app/src/ctr_fs.rs
+++ b/cloudpoint_app/src/ctr_fs.rs
@@ -116,12 +116,7 @@ impl CtrArchive {
 
 impl Drop for CtrArchive {
     fn drop(&mut self) {
-        if self.kind == CtrArchiveKind::Savedata {
-            // TODO! Only do this when something has actually been changed.
-            ctr_commit_archive(self.archive_handle).expect("save archive committed");
-        }
-
-        ctr_close_archive(self.archive_handle).expect("archive closed");
+        ctr_close_archive(self.archive_handle).expect("archive should be closable");
     }
 }
 
@@ -161,7 +156,7 @@ impl CtrFile {
 
 impl Drop for CtrFile {
     fn drop(&mut self) {
-        ctr_close_file(self.file_handle).expect("could not close file");
+        ctr_close_file(self.file_handle).expect("file should be closable");
     }
 }
 
@@ -177,6 +172,6 @@ impl CtrDirectory {
 
 impl Drop for CtrDirectory {
     fn drop(&mut self) {
-        ctr_close_directory(self.directory_handle).expect("could not close directory");
+        ctr_close_directory(self.directory_handle).expect("dir should be closable");
     }
 }

--- a/cloudpoint_app/src/main.rs
+++ b/cloudpoint_app/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ctru::{console::Console, services::hid::KeyPad};
+use ctru::{console::Console, services::hid::KeyPad, set_panic_hook};
 use std::collections::HashSet;
 
 mod ctr_fs;
@@ -11,6 +11,8 @@ mod sync;
 mod tree;
 
 fn main() -> Result<()> {
+    set_panic_hook(false);
+
     setup::logging()?;
     setup::sdmc()?;
 

--- a/cloudpoint_app/src/settings.rs
+++ b/cloudpoint_app/src/settings.rs
@@ -6,6 +6,7 @@ pub struct Settings {
     pub base_url: String,
     pub user_key: String,
     pub log: String,
+    pub backup: bool,
 }
 
 pub static SETTINGS: LazyLock<Settings> = LazyLock::new(|| {
@@ -15,6 +16,8 @@ pub static SETTINGS: LazyLock<Settings> = LazyLock::new(|| {
         .set_default("user_key", "foobarbaz")
         .unwrap()
         .set_default("log", "off")
+        .unwrap()
+        .set_default("backup", true)
         .unwrap()
         .add_source(config::File::from_str(
             &fs::read_to_string("sdmc:/3ds/Cloudpoint/settings.ini").unwrap_or_default(),

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -225,7 +225,7 @@ fn dl(
 
 fn backup(local_tree: &Tree<CtrArchiveLeaf>, sync_state: &SyncState) -> Result<()> {
     let root_dir = PathBuf::from(format!(
-        "sdmc:/3ds/Cloudpoint/backups/{:16X}/{:16X}",
+        "sdmc:/3ds/Cloudpoint/backups/{:016X}/{:016X}",
         sync_state.title_id,
         sync_state
             .local_fp

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Result;
 use chunktree::{
     store::MemStore,
-    tree::Tree,
+    tree::{Leaf, Tree},
     version::{Diff, Version, updater::BlockingUpdater},
 };
 use cloudpoint_lib::{
@@ -16,8 +16,14 @@ use cloudpoint_lib::{
     sync::{CtrArchiveKind, SyncAction, SyncState},
     version::VersionDirEntry,
 };
-use ctru::services::hid::KeyPad;
-use std::{collections::HashMap, fs, rc::Rc};
+use ctru::services::{am::Title, hid::KeyPad};
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    io::{self, BufWriter},
+    path::PathBuf,
+    rc::Rc,
+};
 
 pub fn run(
     services: &mut CtrSysServices,
@@ -193,6 +199,10 @@ fn dl(
         return Ok(());
     };
 
+    if SETTINGS.backup {
+        backup(&local_tree, &s)?;
+    }
+
     let diff = Diff::new(&local_ver, &remote_ver);
     let cache = MemStore::default();
     let store = HttpStore::new(Rc::clone(&client), SETTINGS.base_url.clone());
@@ -209,6 +219,35 @@ fn dl(
     write_db(s)?;
 
     println!("Downloaded!");
+
+    Ok(())
+}
+
+fn backup(local_tree: &Tree<CtrArchiveLeaf>, sync_state: &SyncState) -> Result<()> {
+    let root_dir = PathBuf::from(format!(
+        "sdmc:/3ds/Cloudpoint/backups/{:16X}/{:16X}",
+        sync_state.title_id,
+        sync_state
+            .local_fp
+            .expect("Unreachable without local fingerprint")
+    ));
+
+    log::info!("Backing up to {:?}", root_dir);
+
+    for leaf in local_tree.leaves() {
+        let dst_path: PathBuf = root_dir.join(
+            leaf.path()
+                .components()
+                .filter(|c| matches!(c, std::path::Component::Normal(_)))
+                .collect::<PathBuf>(),
+        );
+
+        fs::create_dir_all(dst_path.parent().expect("file has parent directory"))?;
+        let mut writer = BufWriter::new(File::create(dst_path)?);
+        io::copy(&mut leaf.data()?, &mut writer)?;
+    }
+
+    log::info!("Backup complete");
 
     Ok(())
 }

--- a/cloudpoint_app/src/tree.rs
+++ b/cloudpoint_app/src/tree.rs
@@ -76,7 +76,7 @@ impl Leaf for CtrArchiveLeaf {
                     .collect::<Vec<_>>();
 
                 for sep in path_separators {
-                    let dir_path = CtrFsPath::new(&format!("{}\0", &self.path[0..=sep]))?;
+                    let dir_path = CtrFsPath::new(&self.path[0..=sep])?;
 
                     if let Err(_) = self.ctx.archive.open_directory(&dir_path) {
                         self.ctx.archive.create_directory(&dir_path)?;

--- a/cloudpoint_lib/src/version.rs
+++ b/cloudpoint_lib/src/version.rs
@@ -48,9 +48,7 @@ pub struct VersionDirEntry {
 
 impl VersionDirEntry {
     pub fn fingerprint(&self) -> Result<u64> {
-        self.name
-            .parse()
-            .context("{self.name} is not named with a valid fingerprint")
+        Ok(u64::from_str_radix(&self.name, 16)?)
     }
 
     pub fn get_version<T: Leaf>(

--- a/cloudpoint_lib/src/version.rs
+++ b/cloudpoint_lib/src/version.rs
@@ -16,7 +16,7 @@ impl VersionDirList {
         title_id: u64,
         mode: CtrArchiveKind,
     ) -> Result<VersionDirList> {
-        let url = format!("{base_url}/sync/{user_key}/titles/{title_id}/{mode}/");
+        let url = format!("{base_url}/sync/{user_key}/titles/{title_id:016X}/{mode}/");
 
         let res = client.get(&url, &[("Accept", "application/json")])?;
 
@@ -61,7 +61,8 @@ impl VersionDirEntry {
         mode: CtrArchiveKind,
         fingerprint: u64,
     ) -> Result<Version<T>> {
-        let url = format!("{base_url}/sync/{user_key}/titles/{title_id}/{mode}/{fingerprint}",);
+        let url =
+            format!("{base_url}/sync/{user_key}/titles/{title_id:016X}/{mode}/{fingerprint:016X}",);
 
         let res = client.get(&url, &[])?;
 
@@ -80,8 +81,8 @@ impl VersionDirEntry {
         version: &Version<T>,
     ) -> Result<()> {
         let url = format!(
-            "{base_url}/sync/{user_key}/titles/{title_id}/{mode}/{}",
-            version.fingerprint(),
+            "{base_url}/sync/{user_key}/titles/{title_id:016X}/{mode}/{fingerprint:016X}",
+            fingerprint = version.fingerprint(),
         );
 
         let body = postcard::to_allocvec(&version)?;
@@ -134,7 +135,7 @@ mod tests {
         let srv = MockServer::start();
         srv.mock(|when, then| {
             when.method("GET")
-                .path(format!("/sync/{USER_KEY}/titles/{TITLE_ID}/savedata/"));
+                .path(format!("/sync/{USER_KEY}/titles/{TITLE_ID:016X}/savedata/"));
             then.status(200).body(
                 r#"[
                     {"name":"12345678","size":123,"mtime":123456789},
@@ -210,7 +211,8 @@ mod tests {
         let srv = MockServer::start();
         srv.mock(|when, then| {
             when.method("GET").path(format!(
-                "/sync/{USER_KEY}/titles/{TITLE_ID}/savedata/12345678"
+                "/sync/{USER_KEY}/titles/{TITLE_ID:016X}/savedata/{fingerprint:016X}",
+                fingerprint = 12345678
             ));
             then.status(200).body(
                 postcard::to_allocvec(&DuckVersion {
@@ -230,7 +232,7 @@ mod tests {
             CtrArchiveKind::Savedata,
             12345678,
         );
-        dbg!(&res);
+
         assert!(res.is_ok());
     }
 
@@ -238,8 +240,10 @@ mod tests {
     fn version_get_fails_on_malformed_data() {
         let srv = MockServer::start();
         srv.mock(|when, then| {
-            when.method("GET")
-                .path(format!("/sync/{USER_KEY}/titles/{TITLE_ID}/save/12345678"));
+            when.method("GET").path(format!(
+                "/sync/{USER_KEY}/titles/{TITLE_ID:016X}/save/{fingerprint:016X}",
+                fingerprint = 12345678
+            ));
             then.status(200)
                 .body(postcard::to_allocvec(b"junk bytes").unwrap());
         });
@@ -292,8 +296,8 @@ mod tests {
         let srv = MockServer::start();
         srv.mock(|when, then| {
             when.method("PUT").path(format!(
-                "/sync/{USER_KEY}/titles/{TITLE_ID}/savedata/{}",
-                v.fingerprint()
+                "/sync/{USER_KEY}/titles/{TITLE_ID:016X}/savedata/{fingerprint:016X}",
+                fingerprint = v.fingerprint()
             ));
             then.status(201);
         });


### PR DESCRIPTION
Make downloads less scary by backing up to a local dir on download.

Can be controlled in settings, defaults to on for now.

A few other bug fixes too.