### PR TITLE
Cleanup and tweaks to naming and structure:

### DIFF
--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -66,7 +66,7 @@ pub fn run(
         )?;
 
         let remote_ver = list.latest();
-        s.remote_fp = remote_ver.and_then(|e| e.fingerprint().ok());
+        let remote_fingerprint = remote_ver.and_then(|e| e.fingerprint().ok());
 
         let local_meta = meta(s.sync_item)?;
         let local_archive = Rc::new(CtrArchive::open(s.sync_item)?);
@@ -77,17 +77,23 @@ pub fn run(
             ChunkStrategy::FixedSize(256 * 1024),
             Concurrency::Serial,
         )?;
-        s.local_fp = Some(local_ver.fingerprint());
+        let local_fingerprint = Some(local_ver.fingerprint());
 
-        println!("Local \x1b[12C{:032x}", s.local_fp.unwrap_or_default());
-        println!("Remote\x1b[12C{:032x}", s.remote_fp.unwrap_or_default());
+        println!(
+            "Local \x1b[12C{:032x}",
+            local_fingerprint.unwrap_or_default()
+        );
+        println!(
+            "Remote\x1b[12C{:032x}",
+            remote_fingerprint.unwrap_or_default()
+        );
 
-        match s.get_action() {
+        match s.get_action(local_fingerprint, remote_fingerprint) {
             SyncAction::NoChange | SyncAction::NoChangeOnInit => {
                 log::info!("local and remote data match for {}", s.sync_item,);
 
-                if s.last_fp.is_none() {
-                    s.last_fp = s.local_fp;
+                if s.synced_fingerprint.is_none() {
+                    s.synced_fingerprint = local_fingerprint;
                     s.save(AppPath::Db)?;
                 }
 
@@ -96,7 +102,7 @@ pub fn run(
             SyncAction::Conflict | SyncAction::ConflictOnInit => {
                 log::info!("changed on server and locally for {}", s.sync_item,);
 
-                match s.last_fp {
+                match s.synced_fingerprint {
                     Some(_) => println!("Changed on server and locally!"),
                     None => println!("Exists on server and locally!"),
                 };
@@ -110,7 +116,13 @@ pub fn run(
                     services.hid.scan_input();
 
                     if services.hid.keys_down().contains(KeyPad::DPAD_UP) {
-                        ul(&mut s, Rc::clone(&client), &local_ver, &local_tree)?;
+                        ul(
+                            &mut s,
+                            Rc::clone(&client),
+                            &local_ver,
+                            &local_tree,
+                            local_fingerprint,
+                        )?;
                         break;
                     } else if services.hid.keys_down().contains(KeyPad::DPAD_DOWN) {
                         dl(
@@ -120,6 +132,7 @@ pub fn run(
                             &local_meta,
                             &local_ver,
                             local_tree,
+                            remote_fingerprint,
                         )?;
                         break;
                     } else if services
@@ -132,7 +145,13 @@ pub fn run(
                 }
             }
             SyncAction::Upload => {
-                ul(&mut s, Rc::clone(&client), &local_ver, &local_tree)?;
+                ul(
+                    &mut s,
+                    Rc::clone(&client),
+                    &local_ver,
+                    &local_tree,
+                    local_fingerprint,
+                )?;
             }
             SyncAction::Download => {
                 dl(
@@ -142,6 +161,7 @@ pub fn run(
                     &local_meta,
                     &local_ver,
                     local_tree,
+                    remote_fingerprint,
                 )?;
             }
         }
@@ -159,6 +179,7 @@ fn ul(
     client: Rc<CurlHttpClient>,
     local_ver: &Version<CtrArchiveLeaf, CtrMeta>,
     local_tree: &Tree<CtrArchiveLeaf>,
+    local_fingerprint: Option<u128>,
 ) -> Result<()> {
     log::info!("Uploading {}", s.sync_item);
     println!("Uploading...");
@@ -178,8 +199,7 @@ fn ul(
         &local_ver,
     )?;
 
-    s.last_fp = Some(local_ver.fingerprint());
-
+    s.synced_fingerprint = local_fingerprint;
     s.save(AppPath::Db)?;
 
     println!("Done!");
@@ -194,6 +214,7 @@ fn dl(
     local_meta: &CtrMeta,
     local_ver: &Version<CtrArchiveLeaf, CtrMeta>,
     local_tree: Tree<CtrArchiveLeaf>,
+    remote_fingerprint: Option<u128>,
 ) -> Result<()> {
     log::info!("Downloading {}", s.sync_item);
     println!("Downloading...");
@@ -203,10 +224,9 @@ fn dl(
         &USER_SETTINGS.base_url,
         &USER_KEY,
         s.sync_item,
-        s.remote_fp
-            .expect("unreachable without a remote version available"),
+        remote_fingerprint.expect("remote_fingerprint should be Some<u128> to init a download"),
     ) else {
-        println!("Failed to fetch version manifest :(");
+        println!("Failed to fetch version manifest for version {remote_fingerprint:?}");
 
         return Ok(());
     };
@@ -255,8 +275,7 @@ fn dl(
 
     archive.finalise()?;
 
-    s.last_fp = Some(remote_ver.fingerprint());
-
+    s.synced_fingerprint = remote_fingerprint;
     s.save(AppPath::Db)?;
 
     println!("Done!");

--- a/cloudpoint_lib/src/store.rs
+++ b/cloudpoint_lib/src/store.rs
@@ -21,7 +21,10 @@ impl HttpStore {
     fn fq_hash_url(&self, hash: u128) -> String {
         let [msb, ..] = hash.to_be_bytes();
 
-        format!("{}/sync/{}/chunks/{:02x}/{}", self.1, self.2, msb, hash)
+        format!(
+            "{}/sync/{}/chunks/{:02x}/{:032x}",
+            self.1, self.2, msb, hash
+        )
     }
 }
 
@@ -75,6 +78,7 @@ impl StoreWrite for HttpStore {
 mod tests {
     use crate::http::CurlHttpClient;
     use chunktree::store::{StoreRead, StoreWrite};
+    use flate2::{Compression, read::GzEncoder};
     use httpmock::prelude::*;
     use std::{
         io::{Cursor, Read},
@@ -110,7 +114,13 @@ mod tests {
         let srv = MockServer::start();
         let get_mock = srv.mock(|when, then| {
             when.method("GET");
-            then.status(200).body(b"test data");
+            then.status(200).body({
+                let mut encoder = GzEncoder::new(Cursor::new(b"test data"), Compression::none());
+                let mut buf = vec![];
+                encoder.read_to_end(&mut buf).ok();
+
+                buf
+            });
         });
 
         let client = CurlHttpClient::new().unwrap();

--- a/cloudpoint_lib/src/sync.rs
+++ b/cloudpoint_lib/src/sync.rs
@@ -37,11 +37,7 @@ pub struct SyncState {
     pub title_publisher: String,
     pub product_code: String,
     pub fs_safe_name: String,
-    pub last_fp: Option<u128>,
-    #[serde(skip)]
-    pub local_fp: Option<u128>,
-    #[serde(skip)]
-    pub remote_fp: Option<u128>,
+    pub synced_fingerprint: Option<u128>,
 }
 
 impl SyncState {
@@ -65,9 +61,7 @@ impl SyncState {
             title_publisher,
             product_code,
             fs_safe_name,
-            last_fp: None,
-            local_fp: None,
-            remote_fp: None,
+            synced_fingerprint: None,
         }
     }
 
@@ -82,15 +76,19 @@ impl SyncState {
         Ok(())
     }
 
-    pub fn get_action(&self) -> SyncAction {
-        match (self.local_fp, self.remote_fp) {
+    pub fn get_action(
+        &self,
+        local_fingerprint: Option<u128>,
+        remote_fingerprint: Option<u128>,
+    ) -> SyncAction {
+        match (local_fingerprint, remote_fingerprint) {
             (None, None) => unreachable!(),
             (None, Some(_)) => SyncAction::Download,
             (Some(_), None) => SyncAction::Upload,
             (Some(l), Some(r)) if l == r => SyncAction::NoChange,
             (Some(_), Some(_)) => {
-                let changed_local = self.local_fp != self.last_fp;
-                let changed_remote = self.remote_fp != self.last_fp;
+                let changed_local = local_fingerprint != self.synced_fingerprint;
+                let changed_remote = remote_fingerprint != self.synced_fingerprint;
 
                 match (changed_local, changed_remote) {
                     (false, true) => SyncAction::Download,
@@ -119,20 +117,18 @@ mod tests {
 
     #[test]
     fn local_only_no_remote() {
-        let mut s = SyncState { ..fixture() };
-        s.local_fp = Some(1);
+        let s = SyncState { ..fixture() };
 
-        let res = s.get_action();
+        let res = s.get_action(Some(1), None);
 
         assert!(matches!(res, SyncAction::Upload));
     }
 
     #[test]
     fn remote_only_no_local() {
-        let mut s = SyncState { ..fixture() };
-        s.remote_fp = Some(1);
+        let s = SyncState { ..fixture() };
 
-        let res = s.get_action();
+        let res = s.get_action(None, Some(1));
 
         assert!(matches!(res, SyncAction::Download));
     }
@@ -140,13 +136,11 @@ mod tests {
     #[test]
     fn local_change_only() {
         let s = SyncState {
-            last_fp: Some(1),
-            local_fp: Some(2),
-            remote_fp: Some(1),
+            synced_fingerprint: Some(1),
             ..fixture()
         };
 
-        let res = s.get_action();
+        let res = s.get_action(Some(2), Some(1));
 
         assert!(matches!(res, SyncAction::Upload));
     }
@@ -154,13 +148,11 @@ mod tests {
     #[test]
     fn remote_change_only() {
         let s = SyncState {
-            last_fp: Some(1),
-            local_fp: Some(1),
-            remote_fp: Some(2),
+            synced_fingerprint: Some(1),
             ..fixture()
         };
 
-        let res = s.get_action();
+        let res = s.get_action(Some(1), Some(2));
 
         assert!(matches!(res, SyncAction::Download));
     }
@@ -168,13 +160,11 @@ mod tests {
     #[test]
     fn both_change() {
         let s = SyncState {
-            last_fp: Some(1),
-            local_fp: Some(2),
-            remote_fp: Some(3),
+            synced_fingerprint: Some(1),
             ..fixture()
         };
 
-        let res = s.get_action();
+        let res = s.get_action(Some(2), Some(3));
 
         assert!(matches!(res, SyncAction::Conflict));
     }
@@ -182,13 +172,11 @@ mod tests {
     #[test]
     fn no_local_with_remote_always_download() {
         let s = SyncState {
-            last_fp: Some(1),
-            local_fp: None,
-            remote_fp: Some(1),
+            synced_fingerprint: Some(1),
             ..fixture()
         };
 
-        let res = s.get_action();
+        let res = s.get_action(None, Some(1));
 
         assert!(matches!(res, SyncAction::Download));
     }
@@ -196,13 +184,11 @@ mod tests {
     #[test]
     fn no_remote_with_local_always_upload() {
         let s = SyncState {
-            last_fp: Some(1),
-            local_fp: Some(1),
-            remote_fp: None,
+            synced_fingerprint: Some(1),
             ..fixture()
         };
 
-        let res = s.get_action();
+        let res = s.get_action(Some(1), None);
 
         assert!(matches!(res, SyncAction::Upload));
     }
@@ -211,25 +197,21 @@ mod tests {
     #[should_panic]
     fn no_remote_no_local_cannot_happen() {
         let s = SyncState {
-            last_fp: Some(1),
-            local_fp: None,
-            remote_fp: None,
+            synced_fingerprint: Some(1),
             ..fixture()
         };
 
-        s.get_action();
+        s.get_action(None, None);
     }
 
     #[test]
     fn matching_local_and_remote_always_no_change() {
         let s = SyncState {
-            last_fp: Some(1),
-            local_fp: Some(2),
-            remote_fp: Some(2),
+            synced_fingerprint: Some(1),
             ..fixture()
         };
 
-        let res = s.get_action();
+        let res = s.get_action(Some(2), Some(2));
 
         assert!(matches!(res, SyncAction::NoChange));
     }
@@ -241,9 +223,7 @@ mod tests {
             title_publisher: "Cloudpoint, Inc.".into(),
             product_code: "XTR-X-ABCD".into(),
             fs_safe_name: "Foo Bar  Yeah ".into(),
-            last_fp: None,
-            local_fp: None,
-            remote_fp: None,
+            synced_fingerprint: None,
         }
     }
 }

--- a/cloudpoint_lib/src/version.rs
+++ b/cloudpoint_lib/src/version.rs
@@ -65,7 +65,7 @@ impl VersionDirEntry {
         fingerprint: u128,
     ) -> Result<Version<T, K>> {
         let url = format!(
-            "{base_url}/sync/{user_key}/archives/{sync_item}/{fingerprint:016X}",
+            "{base_url}/sync/{user_key}/archives/{sync_item}/{fingerprint:032x}",
             sync_item = PathBuf::from(sync_item).display(),
         );
 
@@ -85,7 +85,7 @@ impl VersionDirEntry {
         version: &Version<T, K>,
     ) -> Result<()> {
         let url = format!(
-            "{base_url}/sync/{user_key}/archives/{sync_item}/{fingerprint:016X}",
+            "{base_url}/sync/{user_key}/archives/{sync_item}/{fingerprint:032x}",
             sync_item = PathBuf::from(sync_item).display(),
             fingerprint = version.fingerprint(),
         );
@@ -114,7 +114,8 @@ mod tests {
     use uuid::uuid;
 
     const USER_KEY: Uuid = uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8");
-    const ARCHIVE_ID: u64 = 0x000400001234ABCD;
+    const SYNC_ITEM_ID: u64 = 0x000400001234ABCD;
+    const FINGERPRINT: u128 = 0x1234567890abcdef;
 
     #[test]
     fn fingerprint_fails_on_malformed_name() {
@@ -129,11 +130,11 @@ mod tests {
     #[test]
     fn fingerprint_ok_on_valid_name() {
         let e = VersionDirEntry {
-            name: "000400000007AF00".into(),
+            name: "abff99cc".into(),
             mtime: Default::default(),
         };
 
-        assert_eq!(e.fingerprint().unwrap(), 0x000400000007AF00);
+        assert_eq!(e.fingerprint().unwrap(), 0xabff99cc);
     }
 
     #[test]
@@ -141,7 +142,7 @@ mod tests {
         let srv = MockServer::start();
         srv.mock(|when, then| {
             when.method("GET").path(format!(
-                "/sync/{USER_KEY}/archives/{ARCHIVE_ID:016X}.savedata/"
+                "/sync/{USER_KEY}/archives/{SYNC_ITEM_ID:016X}.savedata/"
             ));
             then.status(200).body(
                 r#"{"paths": [
@@ -156,7 +157,7 @@ mod tests {
             &client,
             &srv.base_url(),
             &USER_KEY,
-            SyncItem::Savedata(ARCHIVE_ID),
+            SyncItem::Savedata(SYNC_ITEM_ID),
         );
 
         assert!(res.is_ok());
@@ -175,7 +176,7 @@ mod tests {
             &client,
             &srv.base_url(),
             &USER_KEY,
-            SyncItem::Savedata(ARCHIVE_ID),
+            SyncItem::Savedata(SYNC_ITEM_ID),
         );
 
         assert!(res.is_ok());
@@ -184,7 +185,6 @@ mod tests {
 
     #[test]
     fn can_get_version() {
-        //TODO! Get a fixture for this instead of duck typing something
         #[derive(Serialize)]
         struct DuckVersion {
             payload: BTreeSet<()>,
@@ -194,8 +194,7 @@ mod tests {
         let srv = MockServer::start();
         srv.mock(|when, then| {
             when.method("GET").path(format!(
-                "/sync/{USER_KEY}/archives/{ARCHIVE_ID:016X}.savedata/{fingerprint:016X}",
-                fingerprint = 12345678
+                "/sync/{USER_KEY}/archives/{SYNC_ITEM_ID:016X}.savedata/{FINGERPRINT:032x}",
             ));
             then.status(200).body(
                 postcard::to_allocvec(&DuckVersion {
@@ -211,8 +210,8 @@ mod tests {
             &client,
             &srv.base_url(),
             &USER_KEY,
-            SyncItem::Savedata(ARCHIVE_ID),
-            12345678,
+            SyncItem::Savedata(SYNC_ITEM_ID),
+            FINGERPRINT,
         );
 
         assert!(res.is_ok());
@@ -223,11 +222,10 @@ mod tests {
         let srv = MockServer::start();
         srv.mock(|when, then| {
             when.method("GET").path(format!(
-                "/sync/{USER_KEY}/archives/{ARCHIVE_ID:016X}.savedata/{fingerprint:016X}",
-                fingerprint = 12345678
+                "/sync/{USER_KEY}/archives/{SYNC_ITEM_ID:016X}.savedata/{FINGERPRINT:032x}",
             ));
             then.status(200)
-                .body(postcard::to_allocvec(b"junk bytes").unwrap());
+                .body(postcard::to_allocvec(b"not gzip").unwrap());
         });
 
         let client = CurlHttpClient::new().unwrap();
@@ -235,8 +233,8 @@ mod tests {
             &client,
             &srv.base_url(),
             &USER_KEY,
-            SyncItem::Savedata(ARCHIVE_ID),
-            12345678,
+            SyncItem::Savedata(SYNC_ITEM_ID),
+            FINGERPRINT,
         );
 
         assert!(res.is_err());
@@ -255,8 +253,8 @@ mod tests {
             &client,
             &srv.base_url(),
             &USER_KEY,
-            SyncItem::Savedata(ARCHIVE_ID),
-            12345678,
+            SyncItem::Savedata(SYNC_ITEM_ID),
+            FINGERPRINT,
         );
 
         assert!(res.is_err());
@@ -267,7 +265,7 @@ mod tests {
         let v = Version::<MemLeaf, ()>::new(
             &Tree::new(Vec::default(), ()),
             (),
-            chunktree::version::ChunkStrategy::Cdc(128, 512, 1024),
+            chunktree::version::ChunkStrategy::FixedSize(256),
             chunktree::version::Concurrency::Serial,
         )
         .unwrap();
@@ -275,8 +273,8 @@ mod tests {
         let srv = MockServer::start();
         srv.mock(|when, then| {
             when.method("PUT").path(format!(
-                "/sync/{USER_KEY}/archives/{ARCHIVE_ID:016X}.savedata/{fingerprint:016X}",
-                fingerprint = v.fingerprint()
+                "/sync/{USER_KEY}/archives/{SYNC_ITEM_ID:016X}.savedata/{fingerprint_from_version:032x}",
+                fingerprint_from_version = v.fingerprint()
             ));
             then.status(201);
         });
@@ -286,7 +284,7 @@ mod tests {
             &client,
             &srv.base_url(),
             &USER_KEY,
-            SyncItem::Savedata(ARCHIVE_ID),
+            SyncItem::Savedata(SYNC_ITEM_ID),
             &v,
         );
 


### PR DESCRIPTION
* Use 032x formatting for chunk files and version files
* Simplify the SyncItem to not store transient fingerprints
* Remove an uneccessary recalc of local fingerprint on SyncItem save