### PR TITLE
Ensure syncs are safe if a user.key has changed (will treat a sync state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/cloudpoint_app/src/db/state.rs
+++ b/cloudpoint_app/src/db/state.rs
@@ -84,7 +84,7 @@ impl StateDb {
 
         let mut process = |sync_item| -> Result<()> {
             if let Some(existing_state) = self.1.get_mut(&sync_item) {
-                if existing_state.add_via_title_id(title_id) {
+                if existing_state.via_title_ids.insert(title_id) {
                     log::info!("updating {sync_item} reached via {title_id:016X}");
                     existing_state.auto_enabled = auto_enabled;
                 } else {

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -61,8 +61,10 @@ fn run_one(
     client: &Rc<CurlHttpClient>,
 ) -> Result<()> {
     if Ac::new()?.wait_internet_connection().is_err() {
-        bail!("You are not connected to the internet");
+        bail!("No internet connection");
     }
+
+    log::info!("Starting sync of {:?}", sync_state.sync_item);
 
     let Ok(smdh) = CtrArchive::smdh(sync_state.sync_item) else {
         log::info!(
@@ -72,13 +74,13 @@ fn run_one(
         bail!("{} not found; was the title deleted?", sync_state.sync_item);
     };
 
+    sync_state.safe_adopt(*USER_KEY);
+
     let title_label = format!(
         "{} ({})",
         smdh.title_short(SmdhLanguage::English),
         smdh.title_publisher(SmdhLanguage::English)
     );
-
-    log::info!("Starting sync of {title_label}",);
 
     sync_progress.label(&title_label).message("Checking").send();
 
@@ -107,9 +109,6 @@ fn run_one(
     log::debug!("Remote: {:032x}", remote_fingerprint.unwrap_or_default());
 
     match sync_state.get_action(local_fingerprint, remote_fingerprint) {
-        SyncAction::Skip => {
-            log::info!("ignoring {}, is not enabled", sync_state.sync_item,);
-        }
         SyncAction::NoChange | SyncAction::NoChangeOnInit => {
             log::info!("local and remote data match for {}", sync_state.sync_item,);
 

--- a/cloudpoint_lib/Cargo.toml
+++ b/cloudpoint_lib/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = { workspace = true }
 chunktree = { workspace = true }
 postcard = { workspace = true }
 log = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
 flate2 = { workspace = true }
 
 [dev-dependencies]

--- a/cloudpoint_lib/src/sync.rs
+++ b/cloudpoint_lib/src/sync.rs
@@ -1,6 +1,7 @@
 use crate::ctr::{CtrSmdh, SmdhLanguage};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, path::PathBuf};
+use uuid::Uuid;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum SyncItem {
@@ -35,6 +36,7 @@ pub struct SyncState {
     pub fs_safe_name: String,
     pub synced_fingerprint: Option<u128>,
     pub via_title_ids: HashSet<u64>,
+    pub via_user_key: Uuid,
 }
 
 impl SyncState {
@@ -59,11 +61,15 @@ impl SyncState {
             fs_safe_name,
             synced_fingerprint: None,
             via_title_ids: HashSet::from([via_title_id]),
+            via_user_key: Uuid::nil(),
         }
     }
 
-    pub fn add_via_title_id(&mut self, via: u64) -> bool {
-        self.via_title_ids.insert(via)
+    pub fn safe_adopt(&mut self, user_key: Uuid) {
+        if self.via_user_key != user_key {
+            self.synced_fingerprint = None;
+            self.via_user_key = user_key;
+        }
     }
 
     pub fn get_action(
@@ -93,7 +99,6 @@ impl SyncState {
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum SyncAction {
-    Skip,
     NoChange,
     NoChangeOnInit,
     Conflict,
@@ -207,6 +212,21 @@ mod tests {
         assert!(matches!(res, SyncAction::NoChange));
     }
 
+    #[test]
+    fn unmatched_user_key_resets_sync_state() {
+        let via_user_key = Uuid::new_v4();
+        let mut s = SyncState {
+            synced_fingerprint: Some(u128::MAX),
+            via_user_key,
+            ..fixture()
+        };
+
+        s.safe_adopt(Uuid::new_v4());
+
+        assert!(s.synced_fingerprint.is_none());
+        assert!(s.via_user_key != via_user_key);
+    }
+
     fn fixture() -> SyncState {
         SyncState {
             sync_item: SyncItem::Savedata(0x00040000_1234ABCD),
@@ -216,6 +236,7 @@ mod tests {
             title_publisher: "Cloudpoint, Inc.".into(),
             fs_safe_name: "Foo Bar  Yeah ".into(),
             synced_fingerprint: None,
+            via_user_key: Uuid::max(),
         }
     }
 }


### PR DESCRIPTION
as new if a change is detected)