### PR TITLE
Implement server request body size limit in Caddy to make abuse a little harder

### DIFF
--- a/cloudpoint_server/Caddyfile.dev
+++ b/cloudpoint_server/Caddyfile.dev
@@ -1,3 +1,6 @@
 :80 {
+    request_body {
+	    max_size 288KB
+    }
     reverse_proxy dufs:5000
 }

--- a/cloudpoint_server/Caddyfile.prod
+++ b/cloudpoint_server/Caddyfile.prod
@@ -1,3 +1,6 @@
 your.domain.here {
+    request_body {
+	    max_size 288KB
+    }
     reverse_proxy dufs:5000
 }


### PR DESCRIPTION
Max chunk is 256KB, so this has 32KB of headroom. Should be plenty.

Closes #78 