### PR TITLE
Better shutdown behaviour

### DIFF
--- a/cloudpoint_app/src/app.rs
+++ b/cloudpoint_app/src/app.rs
@@ -162,15 +162,8 @@ impl App {
         log::debug!("about to drop app and await worker exit");
         drop(app);
         match handle.join() {
-            Ok(Ok(_)) => {
-                log::debug!("app exited cleanly, likely no work in flight");
-            }
-            Ok(Err(e)) => {
-                log::warn!("app exited with a worker error (this is probably fine): {e}");
-            }
-            Err(_) => {
-                log::warn!("app exited and could not join worker thread, this is not expected");
-            }
+            Ok(_) => log::debug!("app exited with clean worker join, likely no work in flight"),
+            Err(_) => log::warn!("app exited and could not join worker, this is not expected"),
         }
 
         Ok(())

--- a/cloudpoint_app/src/app.rs
+++ b/cloudpoint_app/src/app.rs
@@ -25,6 +25,7 @@ pub struct App {
     active_screen: ScreenId,
     modal_stack: Vec<Box<dyn ModalScreen>>,
     _task_tx: Sender<TaskMsg>,
+    _shutdown_tx: Sender<()>,
     ui_rx: Receiver<UiMsg>,
     modal_rx: Receiver<OpenModalMsg>,
 }
@@ -35,10 +36,11 @@ impl App {
         let mut hid = Hid::new()?;
 
         let (task_tx, task_rx) = channel::<TaskMsg>();
+        let (shutdown_tx, shutdown_rx) = channel::<()>();
         let (ui_tx, ui_rx) = channel::<UiMsg>();
         let (modal_tx, modal_rx) = channel::<OpenModalMsg>();
 
-        let handle = setup::start_worker(task_rx, ui_tx, modal_tx)?;
+        let handle = setup::start_worker(task_rx, shutdown_rx, ui_tx, modal_tx)?;
 
         let mut app = App {
             screens: HashMap::from([
@@ -58,6 +60,7 @@ impl App {
             active_screen: ScreenId::Sync,
             modal_stack: Vec::with_capacity(4),
             _task_tx: task_tx,
+            _shutdown_tx: shutdown_tx,
             ui_rx,
             modal_rx,
         };

--- a/cloudpoint_app/src/app/worker.rs
+++ b/cloudpoint_app/src/app/worker.rs
@@ -13,6 +13,7 @@ use std::{
 
 pub fn worker_thread(
     task_rx: Receiver<TaskMsg>,
+    shutdown_rx: Receiver<()>,
     ui_tx: Sender<UiMsg>,
     modal_tx: Sender<OpenModalMsg>,
 ) -> Result<()> {
@@ -69,6 +70,7 @@ pub fn worker_thread(
             Ok(TaskMsg::SyncAuto) => {
                 match sync::run(
                     state_db.states_mut().filter(|s| s.auto_enabled),
+                    &shutdown_rx,
                     ui_tx.clone(),
                     modal_tx.clone(),
                     &client,
@@ -104,6 +106,7 @@ pub fn worker_thread(
                     state_db
                         .states_mut()
                         .filter(|s| s.via_title_ids.contains(&title_id)),
+                    &shutdown_rx,
                     ui_tx.clone(),
                     modal_tx.clone(),
                     &client,

--- a/cloudpoint_app/src/app/worker.rs
+++ b/cloudpoint_app/src/app/worker.rs
@@ -23,7 +23,7 @@ pub fn worker_thread(
             log::debug!("state db and title db loaded from disk on startup");
             (state_db, title_db)
         } else {
-            modal_tx.send(OpenModalMsg::Refresh)?;
+            modal_tx.send(OpenModalMsg::Refresh).ok();
             let state_db = StateDb::new(AppPath::Db, &ui_tx).expect("state db should be creatable");
             let title_db =
                 TitleDb::new(AppPath::Db, &state_db, &ui_tx).expect("title db should be creatable");
@@ -33,32 +33,38 @@ pub fn worker_thread(
         }
     };
 
-    ui_tx.send(UiMsg::RefreshDone {
-        qty_sync_states: state_db.qty_auto(),
-        titles: title_db.titles_sorted_vec(),
-    })?;
+    ui_tx
+        .send(UiMsg::RefreshDone {
+            qty_sync_states: state_db.qty_auto(),
+            titles: title_db.titles_sorted_vec(),
+        })
+        .ok();
 
     let client = Rc::new(CurlHttpClient::new().expect("curl client should be available"));
 
     loop {
         match task_rx.recv() {
             Ok(TaskMsg::Refresh) => {
-                modal_tx.send(OpenModalMsg::Refresh)?;
+                modal_tx.send(OpenModalMsg::Refresh).ok();
                 state_db.refresh(true, &ui_tx)?;
                 title_db.refresh(&state_db, &ui_tx)?;
-                ui_tx.send(UiMsg::RefreshDone {
-                    qty_sync_states: state_db.qty_auto(),
-                    titles: title_db.titles_sorted_vec(),
-                })?;
+                ui_tx
+                    .send(UiMsg::RefreshDone {
+                        qty_sync_states: state_db.qty_auto(),
+                        titles: title_db.titles_sorted_vec(),
+                    })
+                    .ok();
             }
             Ok(TaskMsg::Toggle(title_id)) => {
                 state_db.refresh_for_title_id(title_id, false)?;
                 state_db.toggle_for_title_id(title_id)?;
                 title_db.refresh_links(title_id, &state_db)?;
-                ui_tx.send(UiMsg::RefreshDone {
-                    qty_sync_states: state_db.qty_auto(),
-                    titles: title_db.titles_sorted_vec(),
-                })?;
+                ui_tx
+                    .send(UiMsg::RefreshDone {
+                        qty_sync_states: state_db.qty_auto(),
+                        titles: title_db.titles_sorted_vec(),
+                    })
+                    .ok();
             }
             Ok(TaskMsg::SyncAuto) => {
                 match sync::run(
@@ -68,20 +74,26 @@ pub fn worker_thread(
                     &client,
                 ) {
                     Ok(_) => {
-                        ui_tx.send(UiMsg::SyncDone {
-                            result: "Sync completed".into(),
-                            message: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
-                        })?;
+                        ui_tx
+                            .send(UiMsg::SyncDone {
+                                result: "Sync completed".into(),
+                                message: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
+                            })
+                            .ok();
                     }
                     Err(e) => {
-                        ui_tx.send(UiMsg::SyncDone {
-                            result: "Sync failed".into(),
-                            message: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
-                        })?;
-                        modal_tx.send(OpenModalMsg::Error {
-                            label: "Error".into(),
-                            message: e.to_string(),
-                        })?;
+                        ui_tx
+                            .send(UiMsg::SyncDone {
+                                result: "Sync failed".into(),
+                                message: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
+                            })
+                            .ok();
+                        modal_tx
+                            .send(OpenModalMsg::Error {
+                                label: "Error".into(),
+                                message: e.to_string(),
+                            })
+                            .ok();
                     }
                 };
             }
@@ -97,41 +109,53 @@ pub fn worker_thread(
                     &client,
                 ) {
                     Ok(_) => {
-                        ui_tx.send(UiMsg::SyncDone {
-                            result: "Sync completed".into(),
-                            message: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
-                        })?;
+                        ui_tx
+                            .send(UiMsg::SyncDone {
+                                result: "Sync completed".into(),
+                                message: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
+                            })
+                            .ok();
                     }
                     Err(e) => {
-                        ui_tx.send(UiMsg::SyncDone {
-                            result: "Sync failed".into(),
-                            message: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
-                        })?;
-                        modal_tx.send(OpenModalMsg::Error {
-                            label: "Error".into(),
-                            message: e.to_string(),
-                        })?;
+                        ui_tx
+                            .send(UiMsg::SyncDone {
+                                result: "Sync failed".into(),
+                                message: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
+                            })
+                            .ok();
+                        modal_tx
+                            .send(OpenModalMsg::Error {
+                                label: "Error".into(),
+                                message: e.to_string(),
+                            })
+                            .ok();
                     }
                 };
-                ui_tx.send(UiMsg::RefreshDone {
-                    qty_sync_states: state_db.qty_auto(),
-                    titles: title_db.titles_sorted_vec(),
-                })?;
+                ui_tx
+                    .send(UiMsg::RefreshDone {
+                        qty_sync_states: state_db.qty_auto(),
+                        titles: title_db.titles_sorted_vec(),
+                    })
+                    .ok();
             }
             Ok(TaskMsg::LinkHost) => {
                 if let Err(e) = link::host(&ui_tx, &modal_tx) {
                     log::error!("errored during user key share as host: {e}");
-                    ui_tx.send(UiMsg::LinkUpdate {
-                        state: link::LinkState::Failed,
-                    })?;
+                    ui_tx
+                        .send(UiMsg::LinkUpdate {
+                            state: link::LinkState::Failed,
+                        })
+                        .ok();
                 }
             }
             Ok(TaskMsg::LinkClient) => {
                 if let Err(e) = link::client(&ui_tx, &modal_tx) {
                     log::error!("errored during user key share as client: {e}");
-                    ui_tx.send(UiMsg::LinkUpdate {
-                        state: link::LinkState::Failed,
-                    })?;
+                    ui_tx
+                        .send(UiMsg::LinkUpdate {
+                            state: link::LinkState::Failed,
+                        })
+                        .ok();
                 }
             }
             Err(e) => {

--- a/cloudpoint_app/src/link.rs
+++ b/cloudpoint_app/src/link.rs
@@ -39,7 +39,7 @@ const CTRL_FIN_ERR: u8 = 0x05;
 
 pub fn host(ui_tx: &Sender<UiMsg>, modal_tx: &Sender<OpenModalMsg>) -> Result<()> {
     let (quit_tx, quit_rx) = mpsc::channel::<()>();
-    modal_tx.send(OpenModalMsg::LinkHost { quit_tx })?;
+    modal_tx.send(OpenModalMsg::LinkHost { quit_tx }).ok();
 
     let mut uds = Uds::new(None)?;
     uds.create_network(COMM_ID, None, Some(2), PASSPHRASE, CHANNEL)?;
@@ -65,15 +65,17 @@ pub fn host(ui_tx: &Sender<UiMsg>, modal_tx: &Sender<OpenModalMsg>) -> Result<()
                 uds.allow_new_clients(false)?;
                 let fc = u64::from_le_bytes(buf[1..9].try_into()?);
                 state = LinkState::WaitingHost((client_node, fc));
-                ui_tx.send(UiMsg::LinkHostConfirm {
-                    state,
-                    friend_code: format_friend_code_seed(fc),
-                    reply_tx: reply_tx.clone(),
-                })?;
+                ui_tx
+                    .send(UiMsg::LinkHostConfirm {
+                        state,
+                        friend_code: format_friend_code_seed(fc),
+                        reply_tx: reply_tx.clone(),
+                    })
+                    .ok();
             }
             Ok(Some((buf, ..))) if buf[0] == CTRL_FIN_OK => {
                 state = LinkState::Succeeded;
-                ui_tx.send(UiMsg::LinkUpdate { state })?;
+                ui_tx.send(UiMsg::LinkUpdate { state }).ok();
                 break;
             }
             Ok(Some((buf, ..))) if buf[0] == CTRL_FIN_ERR => {
@@ -98,7 +100,7 @@ pub fn host(ui_tx: &Sender<UiMsg>, modal_tx: &Sender<OpenModalMsg>) -> Result<()
                     pkt[9..25].copy_from_slice(USER_KEY.as_bytes());
                     uds.send_packet(&pkt, client_node, 1, SendFlags::Default)?;
                     state = LinkState::WaitingClient((NodeID::None, *USER_KEY));
-                    ui_tx.send(UiMsg::LinkUpdate { state })?;
+                    ui_tx.send(UiMsg::LinkUpdate { state }).ok();
                 }
                 SharePermission::Deny => {
                     uds.eject_client(client_node)?;
@@ -114,7 +116,7 @@ pub fn host(ui_tx: &Sender<UiMsg>, modal_tx: &Sender<OpenModalMsg>) -> Result<()
 pub fn client(ui_tx: &Sender<UiMsg>, modal_tx: &Sender<OpenModalMsg>) -> Result<()> {
     let (quit_tx, quit_rx) = mpsc::channel::<()>();
     let fc = get_friend_code_seed()?;
-    modal_tx.send(OpenModalMsg::LinkClient { fc, quit_tx })?;
+    modal_tx.send(OpenModalMsg::LinkClient { fc, quit_tx }).ok();
 
     let mut uds = Uds::new(None)?;
 
@@ -162,11 +164,13 @@ pub fn client(ui_tx: &Sender<UiMsg>, modal_tx: &Sender<OpenModalMsg>) -> Result<
 
                 let new_user_key = Uuid::from_slice(&buf[9..25])?;
                 state = LinkState::WaitingClient((host_node, new_user_key));
-                ui_tx.send(UiMsg::LinkClientConfirm {
-                    state,
-                    new_user_key: new_user_key.as_simple().to_string(),
-                    reply_tx: reply_tx.clone(),
-                })?;
+                ui_tx
+                    .send(UiMsg::LinkClientConfirm {
+                        state,
+                        new_user_key: new_user_key.as_simple().to_string(),
+                        reply_tx: reply_tx.clone(),
+                    })
+                    .ok();
             }
             Ok(Some((buf, ..))) if buf[0] == CTRL_FIN_ERR => {
                 bail!("other side hung up");
@@ -187,13 +191,13 @@ pub fn client(ui_tx: &Sender<UiMsg>, modal_tx: &Sender<OpenModalMsg>) -> Result<
                     backup_user_key()?;
                     persist_user_key(new_user_key)?;
                     state = LinkState::Succeeded;
-                    ui_tx.send(UiMsg::LinkUpdate { state })?;
+                    ui_tx.send(UiMsg::LinkUpdate { state }).ok();
                     uds.send_packet(&[CTRL_FIN_OK], client_node, CHANNEL, SendFlags::Default)?;
                     break;
                 }
                 SharePermission::Deny => {
                     state = LinkState::Failed;
-                    ui_tx.send(UiMsg::LinkUpdate { state })?;
+                    ui_tx.send(UiMsg::LinkUpdate { state }).ok();
                     uds.send_packet(&[CTRL_FIN_ERR], client_node, CHANNEL, SendFlags::Default)?;
                     break;
                 }

--- a/cloudpoint_app/src/setup.rs
+++ b/cloudpoint_app/src/setup.rs
@@ -32,6 +32,7 @@ pub fn ambient_ctr_services() -> Result<(Am, RomFS, Soc, Gfx)> {
 
 pub fn start_worker(
     task_rx: Receiver<TaskMsg>,
+    shutdown_rx: Receiver<()>,
     ui_tx: Sender<UiMsg>,
     modal_tx: Sender<OpenModalMsg>,
 ) -> Result<JoinHandle<Result<()>>> {
@@ -39,7 +40,7 @@ pub fn start_worker(
 
     let handle = std::thread::Builder::new()
         .stack_size(256 * 1024)
-        .spawn(move || worker_thread(task_rx, ui_tx, modal_tx))?;
+        .spawn(move || worker_thread(task_rx, shutdown_rx, ui_tx, modal_tx))?;
 
     Ok(handle)
 }

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -26,7 +26,10 @@ use std::{
     io::{self, BufWriter},
     path::PathBuf,
     rc::Rc,
-    sync::{mpsc::Sender, oneshot},
+    sync::{
+        mpsc::{self, Receiver, Sender},
+        oneshot,
+    },
 };
 
 pub enum ConflictWinner {
@@ -37,6 +40,7 @@ pub enum ConflictWinner {
 
 pub fn run<'a>(
     states: impl Iterator<Item = &'a mut SyncState>,
+    shutdown_rx: &Receiver<()>,
     ui_tx: Sender<UiMsg>,
     modal_tx: Sender<OpenModalMsg>,
     client: &Rc<CurlHttpClient>,
@@ -48,6 +52,11 @@ pub fn run<'a>(
     let total = states.len();
 
     for (i, sync_state) in states.into_iter().enumerate() {
+        if let Err(mpsc::TryRecvError::Disconnected) = shutdown_rx.try_recv() {
+            log::info!("aborting mid sync due to app shutdown");
+            return Ok(());
+        }
+
         run_one(sync_state, &mut sync_progress, &modal_tx, &client)?;
         sync_progress.progress((i + 1) * 100 / total);
     }


### PR DESCRIPTION
Ensured all UI channel messages are fire and forget; no benefit to returning errors in those cases.

Also introduced a shutdown channel, used during auto sync to quit early (safely) if required.

Closes #80 