### PR TITLE
Ensure title and state db's are recreated after a system format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_json",
+ "twox-hash",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = "1.0.228"
 serde_json = "1.0.149"
 uuid = "1.23.1"
 flate2 = "1.1.9"
+twox-hash = "2.1.2"
 
 [patch.crates-io]
 libz-sys = { path = "patches/libz-sys" }

--- a/cloudpoint_app/Cargo.toml
+++ b/cloudpoint_app/Cargo.toml
@@ -17,6 +17,8 @@ chrono = { workspace = true }
 config = { workspace = true, features = ["ini"] }
 uuid = { workspace = true, features = ["v4"] }
 itertools = { workspace = true }
+twox-hash = { workspace = true }
+
 
 [package.metadata.cargo-3ds]
 romfs_dir = "romfs"

--- a/cloudpoint_app/src/app/worker.rs
+++ b/cloudpoint_app/src/app/worker.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    config::AppPath,
+    config::{AppPath, DEVICE_KEY, REALTIME_DEVICE_KEY, persist_device_key},
     db::{StateDb, TitleDb},
     link, sync,
 };
@@ -18,8 +18,9 @@ pub fn worker_thread(
     modal_tx: Sender<OpenModalMsg>,
 ) -> Result<()> {
     let (mut state_db, mut title_db) = {
-        if let (Ok(state_db), Ok(title_db)) =
-            (StateDb::open(AppPath::Db), TitleDb::open(AppPath::Db))
+        if *REALTIME_DEVICE_KEY == *DEVICE_KEY
+            && let (Ok(state_db), Ok(title_db)) =
+                (StateDb::open(AppPath::Db), TitleDb::open(AppPath::Db))
         {
             log::debug!("state db and title db loaded from disk on startup");
             (state_db, title_db)
@@ -28,8 +29,9 @@ pub fn worker_thread(
             let state_db = StateDb::new(AppPath::Db, &ui_tx).expect("state db should be creatable");
             let title_db =
                 TitleDb::new(AppPath::Db, &state_db, &ui_tx).expect("title db should be creatable");
+            persist_device_key(*REALTIME_DEVICE_KEY).expect("device.key should be creatable");
 
-            log::debug!("state db and title db recreated on startup");
+            log::debug!("state db, title db, device.key recreated on startup");
             (state_db, title_db)
         }
     };

--- a/cloudpoint_app/src/config.rs
+++ b/cloudpoint_app/src/config.rs
@@ -1,3 +1,4 @@
+use crate::{ctr_fs::CtrNand, ctr_title::SD_APP_TITLES};
 use anyhow::Result;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -7,8 +8,6 @@ use std::{
     sync::LazyLock,
 };
 use uuid::Uuid;
-
-use crate::ctr_title::{SD_APP_TITLES, smdh};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Settings {
@@ -88,6 +87,47 @@ pub static APP_VER: LazyLock<String> = LazyLock::new(|| {
     let patch = version & 0xF;
 
     format!("{major}.{minor}.{patch}")
+});
+
+pub static DEVICE_KEY: LazyLock<u128> = LazyLock::new(|| {
+    let path = AppPath::Base.join("device.key");
+
+    if fs::exists(&path).unwrap_or_default() {
+        log::info!("using existing device.key");
+
+        let raw = fs::read(&path).expect("device.key should be accessible");
+        let device_key =
+            u128::from_le_bytes(raw[0..16].try_into().expect("device.key should be a u128"));
+
+        device_key
+    } else {
+        let device_key = *REALTIME_DEVICE_KEY;
+
+        persist_device_key(device_key).expect("device.key should be writable");
+
+        device_key
+    }
+});
+
+pub fn persist_device_key(device_key: u128) -> Result<()> {
+    let path = AppPath::Base.join("device.key");
+
+    fs::write(&path, device_key.to_le_bytes())?;
+
+    Ok(())
+}
+
+pub static REALTIME_DEVICE_KEY: LazyLock<u128> = LazyLock::new(|| {
+    log::info!("fetching device.key from nand");
+
+    let movable_sed = CtrNand::open()
+        .expect("NAND should be accessible")
+        .movable_sed()
+        .expect("movable.sed should be accessible");
+
+    let device_key = twox_hash::XxHash3_128::oneshot(&movable_sed);
+
+    device_key
 });
 
 #[derive(Debug)]

--- a/cloudpoint_app/src/ctr_fs.rs
+++ b/cloudpoint_app/src/ctr_fs.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use cloudpoint_lib::{ctr::CtrSmdh, sync::SyncItem};
 use ctru::services::fs::{ArchiveID, MediaType};
-use ctru_sys::{FS_DirectoryEntry, FS_Path, Handle, PATH_ASCII, PATH_BINARY, fsMakePath};
+use ctru_sys::{
+    FS_DirectoryEntry, FS_OPEN_READ, FS_Path, Handle, PATH_ASCII, PATH_BINARY, PATH_EMPTY,
+    fsMakePath,
+};
 use ffi::{
     ctr_close_archive, ctr_close_directory, ctr_close_file, ctr_commit_archive,
     ctr_create_directory, ctr_create_file, ctr_delete_file, ctr_get_file_size, ctr_open_archive,
@@ -12,6 +15,27 @@ use std::ffi::{CString, c_void};
 use std::io::Error as IoError;
 
 mod ffi;
+
+pub struct CtrNand {
+    nand_handle: u64,
+}
+
+impl CtrNand {
+    pub fn open() -> Result<Self, IoError> {
+        let path = unsafe { fsMakePath(PATH_EMPTY, b"\0".as_ptr() as _) };
+        let nand_handle = ctr_open_archive(ArchiveID::NandCtrFS, path)?;
+
+        Ok(Self { nand_handle })
+    }
+
+    pub fn movable_sed(&self) -> Result<Vec<u8>, IoError> {
+        let path = CtrFsPath::new("/private/movable.sed")?;
+        let file_handle = ctr_open_file(self.nand_handle, path.fs_path(), FS_OPEN_READ)?;
+        let data = ctr_read_file(file_handle, 0, 288)?;
+
+        Ok(data)
+    }
+}
 
 struct CtrArchivePath {
     _sync_item: SyncItem,


### PR DESCRIPTION
This avoids the surprising behaviour of a formatted console happily uploading freshly installed empty game saves on first sync.