### PR TITLE
Terraria oom on upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +279,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
+ "lru",
  "postcard",
  "serde",
  "serde_json",
@@ -563,6 +570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,7 +733,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -728,6 +741,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -1113,6 +1131,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.0",
+]
 
 [[package]]
 name = "macaddr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0.149"
 uuid = "1.23.1"
 flate2 = "1.1.9"
 twox-hash = "2.1.2"
+lru = "0.18.0"
 
 [patch.crates-io]
 libz-sys = { path = "patches/libz-sys" }

--- a/cloudpoint_app/src/app/worker.rs
+++ b/cloudpoint_app/src/app/worker.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    config::{AppPath, DEVICE_KEY, REALTIME_DEVICE_KEY, persist_device_key},
+    config::{APP_VER, AppPath, DEVICE_KEY, REALTIME_DEVICE_KEY, persist_device_key},
     db::{StateDb, TitleDb},
     link, sync,
 };
@@ -43,7 +43,7 @@ pub fn worker_thread(
         })
         .ok();
 
-    let client = Rc::new(CurlHttpClient::new().expect("curl client should be available"));
+    let client = Rc::new(CurlHttpClient::new(&APP_VER).expect("curl client should be available"));
 
     loop {
         match task_rx.recv() {

--- a/cloudpoint_app/src/ctr_fs.rs
+++ b/cloudpoint_app/src/ctr_fs.rs
@@ -115,11 +115,7 @@ impl CtrArchive {
     }
 
     pub fn open_file(&self, path: &CtrFsPath, flags: u8) -> Result<CtrFile, IoError> {
-        log::debug!(
-            "opening file {:?} in archive for {:?}",
-            path,
-            self.sync_item
-        );
+        log::debug!("opening file {:?} in archive for {}", path, self.sync_item);
 
         let file_handle = ctr_open_file(self.archive_handle, path.fs_path(), flags)?;
         let size = ctr_get_file_size(file_handle)?;
@@ -132,28 +128,20 @@ impl CtrArchive {
     }
 
     pub fn create_file(&self, path: &CtrFsPath, size: u64) -> Result<(), IoError> {
-        log::debug!(
-            "creating file {:?} in archive for {:?}",
-            path,
-            self.sync_item
-        );
+        log::debug!("creating file {:?} in archive for {}", path, self.sync_item);
 
         ctr_create_file(self.archive_handle, path.fs_path(), size)
     }
 
     pub fn delete_file(&self, path: &CtrFsPath) -> Result<(), IoError> {
-        log::debug!(
-            "deleting file {:?} in archive for {:?}",
-            path,
-            self.sync_item
-        );
+        log::debug!("deleting file {:?} in archive for {}", path, self.sync_item);
 
         ctr_delete_file(self.archive_handle, path.fs_path())
     }
 
     pub fn open_directory(&self, path: &CtrFsPath) -> Result<CtrDirectory, IoError> {
         log::debug!(
-            "opening directory {:?} in archive for {:?}",
+            "opening directory {:?} in archive for {}",
             path,
             self.sync_item
         );
@@ -165,7 +153,7 @@ impl CtrArchive {
 
     pub fn create_directory(&self, path: &CtrFsPath) -> Result<(), IoError> {
         log::debug!(
-            "creating directory {:?} in archive for {:?}",
+            "creating directory {:?} in archive for {}",
             path,
             self.sync_item
         );
@@ -174,7 +162,7 @@ impl CtrArchive {
     }
 
     pub fn finalise(&self) -> Result<(), IoError> {
-        log::debug!("finalising save write in archive for {:?}", self.sync_item);
+        log::debug!("finalising save write in archive for {}", self.sync_item);
 
         if let SyncItem::Savedata(title_id) = self.sync_item {
             ctr_commit_archive(self.archive_handle)?;
@@ -187,7 +175,7 @@ impl CtrArchive {
 
 impl Drop for CtrArchive {
     fn drop(&mut self) {
-        log::debug!("dropping archive for {:?}", self.sync_item);
+        log::debug!("dropping archive for {}", self.sync_item);
         ctr_close_archive(self.archive_handle).expect("archive should be closable");
     }
 }

--- a/cloudpoint_app/src/ctr_fs.rs
+++ b/cloudpoint_app/src/ctr_fs.rs
@@ -12,7 +12,7 @@ use ffi::{
     ctr_read_title_smdh, ctr_reset_secure_save_meta, ctr_set_file_size, ctr_write_file,
 };
 use std::ffi::{CString, c_void};
-use std::io::Error as IoError;
+use std::io::{self, Error as IoError, Read, Seek, SeekFrom};
 
 mod ffi;
 
@@ -31,7 +31,13 @@ impl CtrNand {
     pub fn movable_sed(&self) -> Result<Vec<u8>, IoError> {
         let path = CtrFsPath::new("/private/movable.sed")?;
         let file_handle = ctr_open_file(self.nand_handle, path.fs_path(), FS_OPEN_READ)?;
-        let data = ctr_read_file(file_handle, 0, 288)?;
+        let size = ctr_get_file_size(file_handle)?;
+        let mut file = CtrFile {
+            file_handle,
+            size,
+            pos: 0,
+        };
+        let data = file.read_to_vec(0, 288)?;
 
         Ok(data)
     }
@@ -84,7 +90,7 @@ pub struct CtrArchive {
 
 impl CtrArchive {
     pub fn smdh(sync_item: SyncItem) -> Result<CtrSmdh, IoError> {
-        log::debug!("fetching smdh for {:?}", sync_item);
+        log::debug!("fetching smdh for {}", sync_item);
 
         match sync_item {
             SyncItem::Savedata(title_id) => Ok(ctr_read_title_smdh(title_id)?.into()),
@@ -93,7 +99,7 @@ impl CtrArchive {
     }
 
     pub fn open(sync_item: SyncItem) -> Result<Self, IoError> {
-        log::debug!("opening archive for {:?}", sync_item);
+        log::debug!("opening archive for {}", sync_item);
 
         let path = CtrArchivePath::new(sync_item)?;
         let handle = ctr_open_archive(path.archive_id, path.fs_path())?;
@@ -115,8 +121,13 @@ impl CtrArchive {
             self.sync_item
         );
 
+        let file_handle = ctr_open_file(self.archive_handle, path.fs_path(), flags)?;
+        let size = ctr_get_file_size(file_handle)?;
+
         Ok(CtrFile {
-            file_handle: ctr_open_file(self.archive_handle, path.fs_path(), flags)?,
+            file_handle,
+            size,
+            pos: 0,
         })
     }
 
@@ -196,18 +207,23 @@ impl CtrFsPath {
 
 pub struct CtrFile {
     file_handle: Handle,
+    pos: u64,
+    size: u64,
 }
 
 impl CtrFile {
-    pub fn read(&self, offset: u64, length: u64) -> Result<Vec<u8>, IoError> {
+    pub fn read_to_vec(&mut self, offset: u64, length: u64) -> Result<Vec<u8>, IoError> {
         log::debug!(
-            "reading from handle {} at offset {} with length {}",
+            "reading to owned vec from handle {} at offset {} with length {}",
             self.file_handle,
             offset,
             length
         );
 
-        ctr_read_file(self.file_handle, offset, length)
+        let mut buf = vec![0u8; length as usize];
+        self.read_exact(&mut buf)?;
+
+        Ok(buf)
     }
 
     pub fn write(&self, offset: u64, buffer: &[u8], flags: u16) -> Result<(), IoError> {
@@ -235,6 +251,52 @@ impl CtrFile {
         );
 
         ctr_set_file_size(self.file_handle, size)
+    }
+}
+
+impl Read for CtrFile {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        log::debug!(
+            "reading to provided buffer (of len {}) from handle {} at offset {}",
+            buf.len(),
+            self.file_handle,
+            self.pos,
+        );
+
+        let bytes_to_eof = match self.size.checked_sub(self.pos) {
+            Some(0) | None => {
+                return Ok(0);
+            }
+            Some(n) => n,
+        };
+
+        let bytes_to_read = (buf.len() as u64).min(bytes_to_eof) as usize;
+
+        let n = ctr_read_file(self.file_handle, self.pos, &mut buf[..bytes_to_read])?;
+        self.pos += n;
+
+        Ok(n as usize)
+    }
+}
+
+impl Seek for CtrFile {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let new_pos = match pos {
+            SeekFrom::Start(n) => n as i64,
+            SeekFrom::End(n) => self.size as i64 + n,
+            SeekFrom::Current(n) => self.pos as i64 + n,
+        };
+
+        if new_pos < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "cannot seek to before start",
+            ));
+        }
+
+        self.pos = new_pos as u64;
+
+        Ok(self.pos)
     }
 }
 

--- a/cloudpoint_app/src/ctr_fs/ffi.rs
+++ b/cloudpoint_app/src/ctr_fs/ffi.rs
@@ -63,11 +63,11 @@ pub(super) fn ctr_read_title_smdh(title_id: u64) -> Result<Vec<u8>, IoError> {
         ));
     }
 
-    let smdh = ctr_read_file(file_handle, 0, 0x36c0)?;
-
+    let mut buf = vec![0; 0x36c0];
+    ctr_read_file(file_handle, 0, &mut buf)?;
     ctr_close_file(file_handle)?;
 
-    Ok(smdh)
+    Ok(buf)
 }
 
 pub(super) fn ctr_read_ext_smdh(save_id: u64) -> Result<Vec<u8>, IoError> {
@@ -256,9 +256,9 @@ pub(super) fn ctr_open_file(
 pub(super) fn ctr_read_file(
     file_handle: Handle,
     offset: u64,
-    length: u64,
-) -> Result<Vec<u8>, IoError> {
-    let mut buffer = vec![0u8; length as usize];
+    buf: &mut [u8],
+) -> Result<u64, IoError> {
+    let length = buf.len() as u64;
     let mut bytes_read: u32 = 0;
 
     let res = unsafe {
@@ -266,7 +266,7 @@ pub(super) fn ctr_read_file(
             file_handle,
             &mut bytes_read,
             offset,
-            buffer.as_mut_ptr() as *mut _,
+            buf.as_mut_ptr() as *mut _,
             length as u32,
         )
     };
@@ -274,7 +274,7 @@ pub(super) fn ctr_read_file(
     // This call sometimes signals failure even though all bytes were read, so use this
     // to determine if this call succeeded rather than checking the res code
     if bytes_read == length as u32 {
-        Ok(buffer)
+        Ok(length)
     } else {
         Err(IoError::new(
             IoErrorKind::Other,

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -45,6 +45,8 @@ pub fn run<'a>(
     modal_tx: Sender<OpenModalMsg>,
     client: &Rc<CurlHttpClient>,
 ) -> Result<()> {
+    log::info!("starting sync");
+
     let _keep_awake = KeepAwake::new();
     let mut sync_progress = SyncProgress::new(ui_tx);
 
@@ -57,9 +59,16 @@ pub fn run<'a>(
             return Ok(());
         }
 
-        run_one(sync_state, &mut sync_progress, &modal_tx, &client)?;
-        sync_progress.progress((i + 1) * 100 / total);
+        match run_one(sync_state, &mut sync_progress, &modal_tx, &client) {
+            Ok(_) => sync_progress.progress((i + 1) * 100 / total),
+            Err(e) => {
+                log::error!("failed mid sync: {e}");
+                return Err(e);
+            }
+        };
     }
+
+    log::info!("completed sync");
 
     Ok(())
 }

--- a/cloudpoint_app/src/tree.rs
+++ b/cloudpoint_app/src/tree.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use chunktree::tree::{Leaf, Tree, TreeError};
 use cloudpoint_lib::sync::SyncItem;
 use ctru_sys::{FS_ATTRIBUTE_DIRECTORY, FS_OPEN_READ, FS_OPEN_WRITE, FS_WRITE_FLUSH};
-use std::io::{self, Cursor};
+use std::io;
 use std::rc::Rc;
 use std::{
     collections::HashMap,
@@ -50,10 +50,9 @@ impl Leaf for CtrArchiveLeaf {
     fn data(&self) -> Result<impl io::Read + io::Seek, TreeError> {
         let path = CtrFsPath::new(&self.path)?;
         let file = self.ctx.archive.open_file(&path, FS_OPEN_READ)?;
-        let file_size = file.size()?;
-        let data = file.read(0, file_size)?;
+        let reader = io::BufReader::with_capacity(256 * 1024, file);
 
-        Ok(Cursor::new(data))
+        Ok(reader)
     }
 
     fn len(&self) -> Result<u64, TreeError> {
@@ -86,8 +85,8 @@ impl Leaf for CtrArchiveLeaf {
                         SyncItem::Extdata(_) => {
                             log::debug!("setting length for {} via recreate", &self.path);
 
-                            let file = self.ctx.archive.open_file(&path, FS_OPEN_READ)?;
-                            let mut buffer = file.read(0, curr_size)?;
+                            let mut file = self.ctx.archive.open_file(&path, FS_OPEN_READ)?;
+                            let mut buffer = file.read_to_vec(0, curr_size)?;
                             buffer.resize(length as usize, 0x00);
                             drop(file);
 

--- a/cloudpoint_lib/Cargo.toml
+++ b/cloudpoint_lib/Cargo.toml
@@ -15,6 +15,7 @@ postcard = { workspace = true }
 log = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 flate2 = { workspace = true }
+lru = { workspace = true }
 
 [dev-dependencies]
 httpmock = { workspace = true }

--- a/cloudpoint_lib/src/http.rs
+++ b/cloudpoint_lib/src/http.rs
@@ -12,8 +12,6 @@ use libc::c_void;
 use std::ffi::CString;
 use std::ptr;
 
-const CAINFO: &str = "romfs:/cacert.pem";
-
 #[derive(Debug)]
 pub struct Response {
     pub status: u32,
@@ -38,7 +36,6 @@ fn check(code: CURLcode) -> Result<()> {
 
 impl CurlHttpClient {
     pub fn new() -> Result<Self> {
-        let cainfo_c = CString::new(CAINFO)?;
         let handle = unsafe { curl_easy_init() };
         if handle.is_null() {
             bail!("libcurl error: curl_easy_init failed")
@@ -46,7 +43,8 @@ impl CurlHttpClient {
 
         // Options that never change across requests.
         unsafe {
-            curl_easy_setopt(handle, CURLOPT_CAINFO, cainfo_c.as_ptr() as *const c_void);
+            let cainfo_c = CString::new("romfs:/cacert.pem")?;
+            curl_easy_setopt(handle, CURLOPT_CAINFO, cainfo_c.as_ptr() as *const c_void); // curl copies value so ptr can drop after fn
             curl_easy_setopt(handle, CURLOPT_TIMEOUT, 30_i64);
             curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT, 10_i64);
             curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1_i64);
@@ -90,9 +88,11 @@ impl CurlHttpClient {
         self.set_long(CURLOPT_NOBODY, 0)?;
         self.set_long(CURLOPT_UPLOAD, 0)?;
         self.set_long(CURLOPT_POST, 0)?;
+        self.set_ptr(CURLOPT_URL, ptr::null())?;
         self.set_ptr(CURLOPT_CUSTOMREQUEST, ptr::null())?;
         self.set_ptr(CURLOPT_READFUNCTION, ptr::null())?;
         self.set_ptr(CURLOPT_READDATA, ptr::null())?;
+        self.set_ptr(CURLOPT_HTTPHEADER, ptr::null())?;
         self.set_off_t(CURLOPT_INFILESIZE_LARGE, -1)?;
         Ok(())
     }

--- a/cloudpoint_lib/src/http.rs
+++ b/cloudpoint_lib/src/http.rs
@@ -35,7 +35,7 @@ fn check(code: CURLcode) -> Result<()> {
 }
 
 impl CurlHttpClient {
-    pub fn new() -> Result<Self> {
+    pub fn new(app_ver: &str) -> Result<Self> {
         let handle = unsafe { curl_easy_init() };
         if handle.is_null() {
             bail!("libcurl error: curl_easy_init failed")
@@ -45,15 +45,21 @@ impl CurlHttpClient {
         unsafe {
             let cainfo_c = CString::new("romfs:/cacert.pem")?;
             curl_easy_setopt(handle, CURLOPT_CAINFO, cainfo_c.as_ptr() as *const c_void); // curl copies value so ptr can drop after fn
+
+            let ua_c = CString::new(format!("Cloudpoint/{app_ver} (Nintendo 3DS)"))?;
+            curl_easy_setopt(handle, CURLOPT_USERAGENT, ua_c.as_ptr() as *const c_void);
+
             curl_easy_setopt(handle, CURLOPT_TIMEOUT, 30_i64);
             curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT, 10_i64);
             curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1_i64);
             curl_easy_setopt(handle, CURLOPT_MAXREDIRS, 5_i64);
+
             curl_easy_setopt(
                 handle,
                 CURLOPT_WRITEFUNCTION,
                 callbacks::write_cb as *const c_void,
             );
+
             curl_easy_setopt(
                 handle,
                 CURLOPT_HEADERFUNCTION,
@@ -302,7 +308,7 @@ mod tests {
             then.status(200).body(&[123]);
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let response = client.get(&srv.url("/test"), &[]).unwrap();
         assert_eq!(response.status, 200);
         assert_eq!(response.body, &[123]);
@@ -316,7 +322,7 @@ mod tests {
             then.status(200);
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let response = client.head(&srv.url("/test"), &[]).unwrap();
         assert_eq!(response.status, 200);
     }
@@ -333,7 +339,7 @@ mod tests {
             });
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let response = client.put(&srv.url("/test"), b"foobar", &[]).unwrap();
         assert_eq!(response.status, 204);
     }

--- a/cloudpoint_lib/src/store.rs
+++ b/cloudpoint_lib/src/store.rs
@@ -106,7 +106,7 @@ mod tests {
             then.status(200);
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let mut store = super::HttpStore::new(Rc::new(client), srv.base_url(), Uuid::new_v4());
 
         let hash = 123;
@@ -131,7 +131,7 @@ mod tests {
             });
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let store = super::HttpStore::new(Rc::new(client), srv.base_url(), Uuid::new_v4());
 
         let mut buf = Vec::new();
@@ -156,7 +156,7 @@ mod tests {
             when.method("PUT");
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let mut store = super::HttpStore::new(Rc::new(client), srv.base_url(), Uuid::new_v4());
 
         let hash = 123;

--- a/cloudpoint_lib/src/store.rs
+++ b/cloudpoint_lib/src/store.rs
@@ -5,17 +5,33 @@ use flate2::{
     Compression,
     read::{GzDecoder, GzEncoder},
 };
+use lru::LruCache;
 use std::{
+    collections::HashSet,
     io::{self, Cursor, Read},
+    num::NonZeroUsize,
     rc::Rc,
+    sync::RwLock,
 };
 use uuid::Uuid;
 
-pub struct HttpStore(Rc<CurlHttpClient>, String, Uuid);
+pub struct HttpStore {
+    http_client: Rc<CurlHttpClient>,
+    base_url: String,
+    user_key: Uuid,
+    upload_dedupe: HashSet<u128>,
+    download_dedupe: RwLock<LruCache<u128, Vec<u8>>>,
+}
 
 impl HttpStore {
     pub fn new(client: Rc<CurlHttpClient>, base_url: String, user_key: Uuid) -> Self {
-        Self(client, base_url, user_key)
+        Self {
+            http_client: client,
+            base_url,
+            user_key,
+            upload_dedupe: HashSet::new(),
+            download_dedupe: RwLock::new(LruCache::new(NonZeroUsize::new(32).unwrap())),
+        }
     }
 
     fn fq_hash_url(&self, hash: u128) -> String {
@@ -23,39 +39,72 @@ impl HttpStore {
 
         format!(
             "{}/sync/{}/chunks/{:02x}/{:032x}",
-            self.1, self.2, msb, hash
+            self.base_url, self.user_key, msb, hash
         )
     }
 }
 
 impl StoreRead for HttpStore {
     fn get_chunk(&self, hash: u128) -> Result<impl Read, StoreError> {
-        log::debug!("getting store chunk for hash {hash}");
+        log::debug!("getting store chunk for hash {hash:032x}");
 
-        let res = self.0.get(&self.fq_hash_url(hash), &[]).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                anyhow!("failed to get chunk {:?}, {}", hash, err),
-            )
-        })?;
+        let mut lru = self
+            .download_dedupe
+            .write()
+            .expect("should be able to lock store lru");
+
+        if let Some(body) = lru.get(&hash) {
+            log::debug!("retrieved chunk {hash:032x} from lru cache");
+
+            return Ok(GzDecoder::new(Cursor::new(body.clone())));
+        }
+
+        let res = self
+            .http_client
+            .get(&self.fq_hash_url(hash), &[])
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    anyhow!("failed to get chunk {hash:032x}, {err}"),
+                )
+            })?;
+
+        log::debug!("adding chunk {hash:032x} to lru cache");
+        lru.put(hash, res.body.clone());
 
         Ok(GzDecoder::new(Cursor::new(res.body)))
     }
 }
 
 impl StoreWrite for HttpStore {
+    fn put_chunks<T: chunktree::tree::Leaf>(
+        &mut self,
+        leaf_chunks: &chunktree::tree::LeafChunks,
+        source: &T,
+    ) -> Result<(), StoreError> {
+        for &(hash, offset, length) in leaf_chunks.chunks() {
+            if self.upload_dedupe.insert(hash) {
+                self.put_chunk(hash, &mut source.read_chunk(offset, length)?)?;
+            } else {
+                log::debug!("skipped upload of chunk {hash:032x}, duplicated within session");
+            }
+        }
+
+        Ok(())
+    }
+
     fn put_chunk(&mut self, hash: u128, data: &mut (impl Read + ?Sized)) -> Result<(), StoreError> {
-        log::debug!("putting store chunk for hash {hash}");
+        log::debug!("putting store chunk for hash {hash:032x}");
 
         let url = self.fq_hash_url(hash);
 
         let should_upload = self
-            .0
+            .http_client
             .head(&url, &[])
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
-                    anyhow!("failed to check existence of chunk {:?}, {}", hash, err),
+                    anyhow!("failed to check existence of chunk {hash:032x}, {err}"),
                 )
             })?
             .status
@@ -64,16 +113,16 @@ impl StoreWrite for HttpStore {
         log::debug!("does store chunk already exist? {should_upload}");
 
         if should_upload {
-            log::debug!("completing upload for hash {hash}");
+            log::debug!("completing upload for hash {hash:032x}");
 
             let mut body = Vec::new();
             let mut gzip_encoder = GzEncoder::new(data, Compression::best());
             gzip_encoder.read_to_end(&mut body)?;
 
-            self.0.put(&url, &body, &[]).map_err(|err| {
+            self.http_client.put(&url, &body, &[]).map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
-                    anyhow!("failed to put chunk {:?}, {}", hash, err),
+                    anyhow!("failed to put chunk {hash:032x}, {err}"),
                 )
             })?;
         }

--- a/cloudpoint_lib/src/sync.rs
+++ b/cloudpoint_lib/src/sync.rs
@@ -90,9 +90,9 @@ impl SyncState {
         remote_fingerprint: Option<u128>,
     ) -> SyncAction {
         log::debug!(
-            "deriving sync action for l={:?} r={:?}",
-            local_fingerprint,
-            remote_fingerprint
+            "deriving sync action for l={:032x} r={:032x}",
+            local_fingerprint.as_ref().unwrap_or(&0),
+            remote_fingerprint.as_ref().unwrap_or(&0)
         );
 
         let result = match (local_fingerprint, remote_fingerprint) {

--- a/cloudpoint_lib/src/version.rs
+++ b/cloudpoint_lib/src/version.rs
@@ -173,7 +173,7 @@ mod tests {
             );
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let res = VersionDirList::try_get(
             &client,
             &srv.base_url(),
@@ -192,7 +192,7 @@ mod tests {
             then.status(200).body(r#"{ "paths": [] }"#);
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let res = VersionDirList::try_get(
             &client,
             &srv.base_url(),
@@ -226,7 +226,7 @@ mod tests {
             );
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let res = VersionDirEntry::get_version::<MemLeaf, ()>(
             &client,
             &srv.base_url(),
@@ -249,7 +249,7 @@ mod tests {
                 .body(postcard::to_allocvec(b"not gzip").unwrap());
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let res = VersionDirEntry::get_version::<MemLeaf, ()>(
             &client,
             &srv.base_url(),
@@ -269,7 +269,7 @@ mod tests {
             then.status(404);
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let res = VersionDirEntry::get_version::<MemLeaf, ()>(
             &client,
             &srv.base_url(),
@@ -300,7 +300,7 @@ mod tests {
             then.status(201);
         });
 
-        let client = CurlHttpClient::new().unwrap();
+        let client = CurlHttpClient::new("0.0.0").unwrap();
         let res = VersionDirEntry::put_version(
             &client,
             &srv.base_url(),


### PR DESCRIPTION
This massive save file (with lots of chunk duplication) was too much for my "it'll be fine!" naive SD reading. Turns out loading 25MB of data every time we wanted to hash 256KB of it was a massive issue.

Implemented proper reading and buffering behaviour, it's much better now (for everything). Also implemented some chunk deduping on upload and download which helps Terraria a lot, and propbably other games too.