### PR TITLE
Proper detection of title reinstalls and title uninstalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ there to be issues. However, I reserve the right to deny access to any obviously
 - Use the same version of a game on all your consoles. Syncing saves to different versions may lead to
   data loss, so avoid this.
 - Take extra care when reinstalling titles or formatting a console; detection of title reinstallation
-  is the thing most likely to lead to unexpected behaviour, so please ensure you have backups before
-  doing either of those things.
+  should now work well (on real hardware at least; emulator support here is patchy), but it is the 
+  thing most likely to lead to unexpected behaviour, so please ensure you have backups before doing 
+  either of those things.
 
 ## FAQ
 
 Q | A
 --- | ---
 I can't see my game in Cloudpoint - where is it? | Make sure you have run a game at least once to initialise the save, and then press (X) to refresh in Cloudpoint - it should then appear.
-What systems are supported? | All 3DS and 2DS variants. performance is pretty good on all of them.
+What systems are supported? | All 3DS and 2DS variants. performance is pretty good on all of them. Emulators do work if you install titles to the system and run the normal home menu, but please be aware that most testing happens on real hardware and some things might not behave quite the same on an emulator. Backups are, as always, recommended.
 Do I *have* to auto sync all my games? I have a lot... | No. Saves and/or extdata for a game can be disabled from the Titles screen (press **L** to view it, then press **Y** to toggle). Disabling auto sync for titles you aren't currently playing will speed auto sync up a great deal. You can still sync any title manually by highlighting it and pressing **A**.
 Can I self host Cloudpoint? | Yes, easily. See its [README.md](./cloudpoint_server/README.md) for setup steps.
 I accidentally downloaded an old save over a newer one! Help! | By default, a backup will be made of any local save before it is replaced. You can use [Checkpoint](https://github.com/BernardoGiordano/Checkpoint) to restore them manually. Either copy the backup to restore into the location Checkpoint expects (and it will then show up there) or add the backup folder to Checkpoint via its config file.
@@ -83,8 +84,6 @@ isn't something which 3DS can natively support, so you will need to manually run
 3DS doesn't provide a method for knowing when a save was last modified, so we can't show that in
 the UI. We *do* know when you last synced a save, so we use that in the UI instead.
 
-Detecting a reinstall of a title is challenging. I am working on 
-
 ## Roadmap
 
 - Time travel; move between server save versions at your leisure.
@@ -92,5 +91,5 @@ Detecting a reinstall of a title is challenging. I am working on
 
 ## Credits
 
-- [devkitPro](https://devkitpro.org/) make all of this possible
-- [Rust3DS](https://github.com/rust3ds) package it all up so I can actually use it
+- [devkitPro](https://devkitpro.org/) makes all of this possible
+- [Rust3DS](https://github.com/rust3ds) packages it all up so I can actually use it

--- a/cloudpoint_app/src/app/worker.rs
+++ b/cloudpoint_app/src/app/worker.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
-    config::{APP_VER, AppPath, DEVICE_KEY, REALTIME_DEVICE_KEY, persist_device_key},
-    db::{StateDb, TitleDb},
+    config::{APP_VER, AppPath},
+    db::{InstallDb, StateDb, TitleDb},
     link, sync,
 };
 use anyhow::Result;
@@ -18,9 +18,8 @@ pub fn worker_thread(
     modal_tx: Sender<OpenModalMsg>,
 ) -> Result<()> {
     let (mut state_db, mut title_db) = {
-        if *REALTIME_DEVICE_KEY == *DEVICE_KEY
-            && let (Ok(state_db), Ok(title_db)) =
-                (StateDb::open(AppPath::Db), TitleDb::open(AppPath::Db))
+        if let (Ok(state_db), Ok(title_db)) =
+            (StateDb::open(AppPath::Db), TitleDb::open(AppPath::Db))
         {
             log::debug!("state db and title db loaded from disk on startup");
             (state_db, title_db)
@@ -29,10 +28,20 @@ pub fn worker_thread(
             let state_db = StateDb::new(AppPath::Db, &ui_tx).expect("state db should be creatable");
             let title_db =
                 TitleDb::new(AppPath::Db, &state_db, &ui_tx).expect("title db should be creatable");
-            persist_device_key(*REALTIME_DEVICE_KEY).expect("device.key should be creatable");
 
-            log::debug!("state db, title db, device.key recreated on startup");
+            log::debug!("state db, title db recreated on startup");
             (state_db, title_db)
+        }
+    };
+
+    let mut install_db = match InstallDb::open(AppPath::Db) {
+        Ok(install_db) => {
+            log::debug!("install db loaded from disk on startup");
+            install_db
+        }
+        Err(_) => {
+            log::debug!("install db recreated on startup");
+            InstallDb::new(AppPath::Db)
         }
     };
 
@@ -49,8 +58,8 @@ pub fn worker_thread(
         match task_rx.recv() {
             Ok(TaskMsg::Refresh) => {
                 modal_tx.send(OpenModalMsg::Refresh).ok();
-                state_db.refresh(true, &ui_tx)?;
-                title_db.refresh(&state_db, &ui_tx)?;
+                state_db.refresh_db(true, &ui_tx)?;
+                title_db.refresh_db(&state_db, &ui_tx)?;
                 ui_tx
                     .send(UiMsg::RefreshDone {
                         qty_sync_states: state_db.qty_auto(),
@@ -59,9 +68,9 @@ pub fn worker_thread(
                     .ok();
             }
             Ok(TaskMsg::Toggle(title_id)) => {
-                state_db.refresh_for_title_id(title_id, false)?;
-                state_db.toggle_for_title_id(title_id)?;
-                title_db.refresh_links(title_id, &state_db)?;
+                state_db.refresh_title(title_id, false)?;
+                state_db.toggle_title(title_id)?;
+                title_db.add_links_for_title(title_id, &state_db)?;
                 ui_tx
                     .send(UiMsg::RefreshDone {
                         qty_sync_states: state_db.qty_auto(),
@@ -76,6 +85,7 @@ pub fn worker_thread(
                     ui_tx.clone(),
                     modal_tx.clone(),
                     &client,
+                    &mut install_db,
                 ) {
                     Ok(_) => {
                         ui_tx
@@ -102,8 +112,8 @@ pub fn worker_thread(
                 };
             }
             Ok(TaskMsg::SyncTargeted(title_id)) => {
-                state_db.refresh_for_title_id(title_id, false)?;
-                title_db.refresh_links(title_id, &state_db)?;
+                state_db.refresh_title(title_id, false)?;
+                title_db.add_links_for_title(title_id, &state_db)?;
                 match sync::run(
                     state_db
                         .states_mut()
@@ -112,6 +122,7 @@ pub fn worker_thread(
                     ui_tx.clone(),
                     modal_tx.clone(),
                     &client,
+                    &mut install_db,
                 ) {
                     Ok(_) => {
                         ui_tx

--- a/cloudpoint_app/src/app/worker.rs
+++ b/cloudpoint_app/src/app/worker.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     config::{APP_VER, AppPath},
-    db::{InstallDb, StateDb, TitleDb},
+    db::{InstallHistoryDb, StateDb, TitleDb},
     link, sync,
 };
 use anyhow::Result;
@@ -17,33 +17,23 @@ pub fn worker_thread(
     ui_tx: Sender<UiMsg>,
     modal_tx: Sender<OpenModalMsg>,
 ) -> Result<()> {
-    let (mut state_db, mut title_db) = {
-        if let (Ok(state_db), Ok(title_db)) =
-            (StateDb::open(AppPath::Db), TitleDb::open(AppPath::Db))
-        {
-            log::debug!("state db and title db loaded from disk on startup");
-            (state_db, title_db)
-        } else {
-            modal_tx.send(OpenModalMsg::Refresh).ok();
-            let state_db = StateDb::new(AppPath::Db, &ui_tx).expect("state db should be creatable");
-            let title_db =
-                TitleDb::new(AppPath::Db, &state_db, &ui_tx).expect("title db should be creatable");
+    let mut state_db = StateDb::open(AppPath::Db)
+        .or_else(|_| StateDb::new(AppPath::Db, &ui_tx))
+        .expect("state db must be available");
 
-            log::debug!("state db, title db recreated on startup");
-            (state_db, title_db)
-        }
-    };
+    let mut title_db = TitleDb::open(AppPath::Db)
+        .or_else(|_| TitleDb::new(AppPath::Db, &state_db, &ui_tx))
+        .expect("title db must be available");
 
-    let mut install_db = match InstallDb::open(AppPath::Db) {
-        Ok(install_db) => {
-            log::debug!("install db loaded from disk on startup");
-            install_db
-        }
-        Err(_) => {
-            log::debug!("install db recreated on startup");
-            InstallDb::new(AppPath::Db)
-        }
-    };
+    let mut install_history_db = InstallHistoryDb::open(AppPath::Db)
+        .or_else(|_| InstallHistoryDb::new(AppPath::Db))
+        .expect("install history db must be available");
+
+    let client = Rc::new(CurlHttpClient::new(&APP_VER).expect("curl client must be available"));
+
+    state_db.prune_orphaned()?;
+    title_db.prune_orphaned()?;
+    // install_db is *not* pruned, we want that to survive title and OS reinstalls
 
     ui_tx
         .send(UiMsg::RefreshDone {
@@ -52,14 +42,12 @@ pub fn worker_thread(
         })
         .ok();
 
-    let client = Rc::new(CurlHttpClient::new(&APP_VER).expect("curl client should be available"));
-
     loop {
         match task_rx.recv() {
             Ok(TaskMsg::Refresh) => {
                 modal_tx.send(OpenModalMsg::Refresh).ok();
-                state_db.refresh_db(true, &ui_tx)?;
-                title_db.refresh_db(&state_db, &ui_tx)?;
+                state_db.add_missing(true, &ui_tx)?;
+                title_db.add_all(&state_db, &ui_tx)?;
                 ui_tx
                     .send(UiMsg::RefreshDone {
                         qty_sync_states: state_db.qty_auto(),
@@ -68,9 +56,9 @@ pub fn worker_thread(
                     .ok();
             }
             Ok(TaskMsg::Toggle(title_id)) => {
-                state_db.refresh_title(title_id, false)?;
-                state_db.toggle_title(title_id)?;
-                title_db.add_links_for_title(title_id, &state_db)?;
+                state_db.process_sync_items_for_title(title_id, false)?;
+                state_db.toggle_auto_sync_for_title(title_id)?;
+                title_db.refresh_shared_extdata_linked_titles(title_id, &state_db)?;
                 ui_tx
                     .send(UiMsg::RefreshDone {
                         qty_sync_states: state_db.qty_auto(),
@@ -85,7 +73,7 @@ pub fn worker_thread(
                     ui_tx.clone(),
                     modal_tx.clone(),
                     &client,
-                    &mut install_db,
+                    &mut install_history_db,
                 ) {
                     Ok(_) => {
                         ui_tx
@@ -112,8 +100,8 @@ pub fn worker_thread(
                 };
             }
             Ok(TaskMsg::SyncTargeted(title_id)) => {
-                state_db.refresh_title(title_id, false)?;
-                title_db.add_links_for_title(title_id, &state_db)?;
+                state_db.process_sync_items_for_title(title_id, false)?;
+                title_db.refresh_shared_extdata_linked_titles(title_id, &state_db)?;
                 match sync::run(
                     state_db
                         .states_mut()
@@ -122,7 +110,7 @@ pub fn worker_thread(
                     ui_tx.clone(),
                     modal_tx.clone(),
                     &client,
-                    &mut install_db,
+                    &mut install_history_db,
                 ) {
                     Ok(_) => {
                         ui_tx

--- a/cloudpoint_app/src/config.rs
+++ b/cloudpoint_app/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{ctr_fs::CtrNand, ctr_title::SD_APP_TITLES};
+use crate::ctr_title::SD_APP_TITLES;
 use anyhow::Result;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -87,47 +87,6 @@ pub static APP_VER: LazyLock<String> = LazyLock::new(|| {
     let patch = version & 0xF;
 
     format!("{major}.{minor}.{patch}")
-});
-
-pub static DEVICE_KEY: LazyLock<u128> = LazyLock::new(|| {
-    let path = AppPath::Base.join("device.key");
-
-    if fs::exists(&path).unwrap_or_default() {
-        log::info!("using existing device.key");
-
-        let raw = fs::read(&path).expect("device.key should be accessible");
-        let device_key =
-            u128::from_le_bytes(raw[0..16].try_into().expect("device.key should be a u128"));
-
-        device_key
-    } else {
-        let device_key = *REALTIME_DEVICE_KEY;
-
-        persist_device_key(device_key).expect("device.key should be writable");
-
-        device_key
-    }
-});
-
-pub fn persist_device_key(device_key: u128) -> Result<()> {
-    let path = AppPath::Base.join("device.key");
-
-    fs::write(&path, device_key.to_le_bytes())?;
-
-    Ok(())
-}
-
-pub static REALTIME_DEVICE_KEY: LazyLock<u128> = LazyLock::new(|| {
-    log::info!("fetching device.key from nand");
-
-    let movable_sed = CtrNand::open()
-        .expect("NAND should be accessible")
-        .movable_sed()
-        .expect("movable.sed should be accessible");
-
-    let device_key = twox_hash::XxHash3_128::oneshot(&movable_sed);
-
-    device_key
 });
 
 #[derive(Debug)]

--- a/cloudpoint_app/src/ctr_fs.rs
+++ b/cloudpoint_app/src/ctr_fs.rs
@@ -1,10 +1,7 @@
 use anyhow::Result;
 use cloudpoint_lib::{ctr::CtrSmdh, sync::SyncItem};
 use ctru::services::fs::{ArchiveID, MediaType};
-use ctru_sys::{
-    FS_DirectoryEntry, FS_OPEN_READ, FS_Path, Handle, PATH_ASCII, PATH_BINARY, PATH_EMPTY,
-    fsMakePath,
-};
+use ctru_sys::{FS_DirectoryEntry, FS_Path, Handle, PATH_ASCII, PATH_BINARY, fsMakePath};
 use ffi::{
     ctr_close_archive, ctr_close_directory, ctr_close_file, ctr_commit_archive,
     ctr_create_directory, ctr_create_file, ctr_delete_file, ctr_get_file_size, ctr_open_archive,
@@ -15,33 +12,6 @@ use std::ffi::{CString, c_void};
 use std::io::{self, Error as IoError, Read, Seek, SeekFrom};
 
 mod ffi;
-
-pub struct CtrNand {
-    nand_handle: u64,
-}
-
-impl CtrNand {
-    pub fn open() -> Result<Self, IoError> {
-        let path = unsafe { fsMakePath(PATH_EMPTY, b"\0".as_ptr() as _) };
-        let nand_handle = ctr_open_archive(ArchiveID::NandCtrFS, path)?;
-
-        Ok(Self { nand_handle })
-    }
-
-    pub fn movable_sed(&self) -> Result<Vec<u8>, IoError> {
-        let path = CtrFsPath::new("/private/movable.sed")?;
-        let file_handle = ctr_open_file(self.nand_handle, path.fs_path(), FS_OPEN_READ)?;
-        let size = ctr_get_file_size(file_handle)?;
-        let mut file = CtrFile {
-            file_handle,
-            size,
-            pos: 0,
-        };
-        let data = file.read_to_vec(0, 288)?;
-
-        Ok(data)
-    }
-}
 
 struct CtrArchivePath {
     _sync_item: SyncItem,

--- a/cloudpoint_app/src/ctr_title.rs
+++ b/cloudpoint_app/src/ctr_title.rs
@@ -1,5 +1,3 @@
-use std::{collections::HashMap, sync::LazyLock};
-
 use crate::ctr_fs::CtrArchive;
 use anyhow::Result;
 use cloudpoint_lib::{
@@ -10,7 +8,8 @@ use ctru::services::{
     am::{Am, Title},
     fs::MediaType,
 };
-use ffi::{ctr_get_title_version, ctr_getr_ext_data_id_for_title};
+use ffi::{ctr_get_ext_data_id_for_title, ctr_get_title_version};
+use std::{collections::HashMap, ffi::CString, fs::read_dir, path::PathBuf, sync::LazyLock};
 
 pub struct CtrAmTitle {
     pub title_id: u64,
@@ -44,6 +43,27 @@ pub static SD_APP_TITLES: LazyLock<HashMap<u64, CtrAmTitle>> = LazyLock::new(|| 
     applications
 });
 
+static SD_TMD_ROOTS: LazyLock<Vec<PathBuf>> = LazyLock::new(|| {
+    let mut roots = Vec::new();
+
+    static EXPECT_MSG: &str =
+        "sdmc:/Nintendo 3DS/<id0>/<id1>/ dirs should always exist and be readble";
+
+    for entry in read_dir("sdmc:/Nintendo 3DS").expect(EXPECT_MSG) {
+        let id0 = entry.expect(EXPECT_MSG);
+        if id0.file_type().expect(EXPECT_MSG).is_dir() && id0.file_name().len() == 32 {
+            for entry in read_dir(id0.path()).expect(EXPECT_MSG) {
+                let id1 = entry.expect(EXPECT_MSG);
+                if id1.file_type().expect(EXPECT_MSG).is_dir() && id1.file_name().len() == 32 {
+                    roots.push(id1.path());
+                }
+            }
+        }
+    }
+
+    roots
+});
+
 pub fn smdh(title_id: u64) -> Result<CtrSmdh> {
     log::debug!("looking up smdh for {title_id} via faked SyncItem");
 
@@ -71,7 +91,7 @@ pub fn lookup_savedata_sync_item_for_title(title_id: u64) -> Option<SyncItem> {
 }
 
 pub fn lookup_extdata_sync_item_for_title(title_id: u64) -> Option<SyncItem> {
-    ctr_getr_ext_data_id_for_title(title_id)
+    ctr_get_ext_data_id_for_title(title_id)
         .ok()
         .and_then(|extdata_id| {
             log::debug!(
@@ -96,12 +116,31 @@ pub fn infer_extdata_sync_item_for_title(title_id: u64) -> Option<SyncItem> {
         .ok()
 }
 
+pub fn get_installed_at_for_title(title_id: u64) -> Result<u64> {
+    let mut latest = 0;
+
+    for root in &*SD_TMD_ROOTS {
+        let tmd_path = CString::new(format!(
+            "{}/title/00040000/{:08x}/content/00000000.tmd",
+            root.display(),
+            title_id as u32
+        ))?;
+
+        let mtime = ffi::ctr_archive_get_mtime(tmd_path)?;
+        latest = latest.max(mtime);
+    }
+
+    Ok(latest)
+}
+
 mod ffi {
     use anyhow::Result;
     use anyhow::bail;
     use ctru::services::fs::MediaType;
     use ctru_sys::AM_GetTitleExtDataId;
+    use ctru_sys::archive_getmtime;
     use ctru_sys::{AM_GetTitleInfo, AM_TitleInfo, MEDIATYPE_SD, R_FAILED};
+    use std::ffi::CString;
 
     pub(super) fn ctr_get_title_version(title_id: u64) -> Result<u16> {
         let mut title_info: AM_TitleInfo = unsafe { std::mem::zeroed() };
@@ -126,7 +165,7 @@ mod ffi {
         Ok(title_info.version)
     }
 
-    pub(super) fn ctr_getr_ext_data_id_for_title(title_id: u64) -> Result<u64> {
+    pub(super) fn ctr_get_ext_data_id_for_title(title_id: u64) -> Result<u64> {
         let mut extdata_id: u64 = 0;
 
         let res = unsafe { AM_GetTitleExtDataId(&mut extdata_id, MediaType::Sd as u8, title_id) };
@@ -140,5 +179,17 @@ mod ffi {
         }
 
         Ok(extdata_id)
+    }
+
+    pub(super) fn ctr_archive_get_mtime(path: CString) -> Result<u64> {
+        let mut mtime: u64 = 0;
+
+        let res = unsafe { archive_getmtime(path.as_ptr(), &mut mtime) };
+
+        if R_FAILED(res) {
+            bail!("could not retreive mtime for {:?}", path);
+        }
+
+        Ok(mtime)
     }
 }

--- a/cloudpoint_app/src/db.rs
+++ b/cloudpoint_app/src/db.rs
@@ -1,7 +1,7 @@
-pub use install::{InstallDb, InstallStatus};
+pub use install_history::{InstallHistoryDb, InstallStatus};
 pub use state::StateDb;
 pub use title::{TitleDb, TitleDetails, TitleSyncStatus};
 
-mod install;
+mod install_history;
 mod state;
 mod title;

--- a/cloudpoint_app/src/db.rs
+++ b/cloudpoint_app/src/db.rs
@@ -1,12 +1,7 @@
-/// These titles don't support sync to another system so are added but not enabled
-/// during discovery. They *can* be synced if later enabled manually.
-pub const UNSUPPORTED_TITLE_IDS: [u64; 1] = [
-    // Super Mario Maker
-    0x00040000001A0500,
-];
-
+pub use install::{InstallDb, InstallStatus};
 pub use state::StateDb;
 pub use title::{TitleDb, TitleDetails, TitleSyncStatus};
 
+mod install;
 mod state;
 mod title;

--- a/cloudpoint_app/src/db/install.rs
+++ b/cloudpoint_app/src/db/install.rs
@@ -1,0 +1,79 @@
+use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use crate::ctr_title::get_installed_at_for_title;
+
+#[derive(Deserialize, Serialize)]
+pub struct InstallDb(#[serde[skip]] PathBuf, HashMap<u64, u64>);
+
+impl InstallDb {
+    pub fn open(root_path: impl AsRef<Path>) -> Result<Self> {
+        log::debug!("loading install db from disk");
+
+        let db_path = root_path.as_ref().join("install.db");
+
+        if let Ok(buf) = fs::read(&db_path) {
+            let mut install_db = postcard::from_bytes::<InstallDb>(&buf)?;
+            install_db.0 = db_path;
+
+            Ok(install_db)
+        } else {
+            bail!("install db not found")
+        }
+    }
+
+    pub fn new(root_path: impl AsRef<Path>) -> Self {
+        log::debug!("building install db");
+
+        let db_path = root_path.as_ref().join("install.db");
+        let install_db = Self(db_path, HashMap::new());
+
+        install_db
+    }
+
+    pub fn save(&mut self) -> Result<()> {
+        log::debug!("saving install db to disk");
+
+        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
+
+        Ok(())
+    }
+
+    pub fn check_install(&self, title_id: u64) -> InstallStatus {
+        let latest_mtime = &get_installed_at_for_title(title_id);
+        let cached = self.1.get(&title_id);
+
+        match (latest_mtime, cached) {
+            (Ok(_), None) => InstallStatus::Updated,
+            (Ok(latest), Some(cached)) if latest != cached => InstallStatus::Updated,
+            (Ok(latest), Some(cached)) if latest == cached => InstallStatus::Unchanged,
+            _ => InstallStatus::Unknown,
+        }
+    }
+
+    pub fn touch(&mut self, title_id: u64) {
+        self.1.insert(
+            title_id,
+            get_installed_at_for_title(title_id)
+                .expect("install mtime should be available for title"),
+        );
+    }
+}
+
+impl Drop for InstallDb {
+    fn drop(&mut self) {
+        self.save()
+            .expect("should be able to save install db on shutdown")
+    }
+}
+
+pub enum InstallStatus {
+    Unknown,
+    Unchanged,
+    Updated,
+}

--- a/cloudpoint_app/src/db/install_history.rs
+++ b/cloudpoint_app/src/db/install_history.rs
@@ -9,46 +9,41 @@ use std::{
 use crate::ctr_title::get_installed_at_for_title;
 
 #[derive(Deserialize, Serialize)]
-pub struct InstallDb(#[serde[skip]] PathBuf, HashMap<u64, u64>);
+pub struct InstallHistoryDb(#[serde[skip]] PathBuf, HashMap<u64, u64>);
 
-impl InstallDb {
+impl InstallHistoryDb {
     pub fn open(root_path: impl AsRef<Path>) -> Result<Self> {
-        log::debug!("loading install db from disk");
+        log::debug!("loading install history db from disk");
 
-        let db_path = root_path.as_ref().join("install.db");
+        let db_path = root_path.as_ref().join("install_history.db");
 
         if let Ok(buf) = fs::read(&db_path) {
-            let mut install_db = postcard::from_bytes::<InstallDb>(&buf)?;
+            let mut install_db = postcard::from_bytes::<InstallHistoryDb>(&buf)?;
             install_db.0 = db_path;
 
             Ok(install_db)
         } else {
-            bail!("install db not found")
+            bail!("install history db not found")
         }
     }
 
-    pub fn new(root_path: impl AsRef<Path>) -> Self {
-        log::debug!("building install db");
+    pub fn new(root_path: impl AsRef<Path>) -> Result<Self> {
+        log::debug!("building install history db");
 
-        let db_path = root_path.as_ref().join("install.db");
+        let db_path = root_path.as_ref().join("install_history.db");
         let install_db = Self(db_path, HashMap::new());
 
-        install_db
+        Ok(install_db)
     }
 
-    pub fn save(&mut self) -> Result<()> {
-        log::debug!("saving install db to disk");
-
-        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
-
-        Ok(())
-    }
-
-    pub fn check_install(&self, title_id: u64) -> InstallStatus {
+    pub fn check(&self, title_id: u64) -> InstallStatus {
         let latest_mtime = &get_installed_at_for_title(title_id);
-        let cached = self.1.get(&title_id);
+        let cached_mtime = self.1.get(&title_id);
 
-        match (latest_mtime, cached) {
+        log::debug!("latest_mtime is {:?}", latest_mtime);
+        log::debug!("cached_mtime is {:?}", cached_mtime);
+
+        match (latest_mtime, cached_mtime) {
             (Ok(_), None) => InstallStatus::Updated,
             (Ok(latest), Some(cached)) if latest != cached => InstallStatus::Updated,
             (Ok(latest), Some(cached)) if latest == cached => InstallStatus::Unchanged,
@@ -63,12 +58,20 @@ impl InstallDb {
                 .expect("install mtime should be available for title"),
         );
     }
+
+    fn save(&mut self) -> Result<()> {
+        log::debug!("saving install history db to disk");
+
+        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
+
+        Ok(())
+    }
 }
 
-impl Drop for InstallDb {
+impl Drop for InstallHistoryDb {
     fn drop(&mut self) {
         self.save()
-            .expect("should be able to save install db on shutdown")
+            .expect("should be able to save install history db on shutdown")
     }
 }
 

--- a/cloudpoint_app/src/db/state.rs
+++ b/cloudpoint_app/src/db/state.rs
@@ -21,7 +21,7 @@ pub struct StateDb(#[serde[skip]] PathBuf, HashMap<SyncItem, SyncState>);
 
 impl StateDb {
     pub fn open(root_path: impl AsRef<Path>) -> Result<Self> {
-        log::debug!("loading all savedata and extdata from disk");
+        log::debug!("loading state db from disk");
 
         let db_path = root_path.as_ref().join("state.db");
 
@@ -36,38 +36,18 @@ impl StateDb {
     }
 
     pub fn new(root_path: impl AsRef<Path>, ui_tx: &Sender<UiMsg>) -> Result<Self> {
-        log::debug!("building all savedata and extdata");
+        log::debug!("building new state db");
 
         let db_path = root_path.as_ref().join("state.db");
 
         let mut state_db = Self(db_path, HashMap::new());
-        state_db.refresh_db(true, ui_tx)?;
+        state_db.add_missing(true, ui_tx)?;
 
         Ok(state_db)
     }
 
-    pub fn save(&mut self) -> Result<()> {
-        log::debug!("saving state db to disk");
-
-        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
-
-        Ok(())
-    }
-
-    pub fn refresh_db(&mut self, auto_enabled: bool, ui_tx: &Sender<UiMsg>) -> Result<()> {
-        log::debug!("refreshing all savedata and extdata");
-
-        let mut refresh_progress = RefreshProgress::new(ui_tx.clone());
-
-        let total = SD_APP_TITLES.len();
-
-        for (i, (&title_id, _)) in SD_APP_TITLES.iter().enumerate() {
-            self.refresh_title(title_id, auto_enabled)?;
-            refresh_progress
-                .message("Refreshing sync items")
-                .progress((i + 1) * 100 / total)
-                .send();
-        }
+    pub fn prune_orphaned(&mut self) -> Result<()> {
+        log::debug!("pruning orphaned state db records");
 
         let current_title_ids = SD_APP_TITLES.keys().copied().collect::<HashSet<_>>();
 
@@ -84,7 +64,29 @@ impl StateDb {
         Ok(())
     }
 
-    pub fn refresh_title(&mut self, title_id: u64, auto_enabled: bool) -> Result<()> {
+    pub fn add_missing(&mut self, auto_enabled: bool, ui_tx: &Sender<UiMsg>) -> Result<()> {
+        log::debug!("adding missing state db records");
+
+        let mut refresh_progress = RefreshProgress::new(ui_tx.clone());
+        let total = SD_APP_TITLES.len();
+
+        for (i, (&title_id, _)) in SD_APP_TITLES.iter().enumerate() {
+            self.process_sync_items_for_title(title_id, auto_enabled)?;
+
+            refresh_progress
+                .message("Refreshing sync items")
+                .progress((i + 1) * 100 / total)
+                .send();
+        }
+
+        Ok(())
+    }
+
+    pub fn process_sync_items_for_title(
+        &mut self,
+        title_id: u64,
+        auto_enabled: bool,
+    ) -> Result<()> {
         log::debug!("processing refresh for title {title_id:016X}");
 
         let mut process = |sync_item| -> Result<()> {
@@ -132,7 +134,7 @@ impl StateDb {
         Ok(())
     }
 
-    pub fn toggle_title(&mut self, title_id: u64) -> Result<()> {
+    pub fn toggle_auto_sync_for_title(&mut self, title_id: u64) -> Result<()> {
         log::debug!("toggling auto sync enabled setting for title {title_id:016X}");
 
         let states = self
@@ -186,6 +188,14 @@ impl StateDb {
 
     pub fn states_mut(&mut self) -> impl Iterator<Item = &mut SyncState> {
         self.1.values_mut()
+    }
+
+    fn save(&mut self) -> Result<()> {
+        log::debug!("saving state db to disk");
+
+        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
+
+        Ok(())
     }
 }
 

--- a/cloudpoint_app/src/db/state.rs
+++ b/cloudpoint_app/src/db/state.rs
@@ -41,7 +41,7 @@ impl StateDb {
         let db_path = root_path.as_ref().join("state.db");
 
         let mut state_db = Self(db_path, HashMap::new());
-        state_db.refresh(true, ui_tx)?;
+        state_db.refresh_db(true, ui_tx)?;
 
         Ok(state_db)
     }
@@ -54,7 +54,7 @@ impl StateDb {
         Ok(())
     }
 
-    pub fn refresh(&mut self, auto_enabled: bool, ui_tx: &Sender<UiMsg>) -> Result<()> {
+    pub fn refresh_db(&mut self, auto_enabled: bool, ui_tx: &Sender<UiMsg>) -> Result<()> {
         log::debug!("refreshing all savedata and extdata");
 
         let mut refresh_progress = RefreshProgress::new(ui_tx.clone());
@@ -62,7 +62,7 @@ impl StateDb {
         let total = SD_APP_TITLES.len();
 
         for (i, (&title_id, _)) in SD_APP_TITLES.iter().enumerate() {
-            self.refresh_for_title_id(title_id, auto_enabled)?;
+            self.refresh_title(title_id, auto_enabled)?;
             refresh_progress
                 .message("Refreshing sync items")
                 .progress((i + 1) * 100 / total)
@@ -84,7 +84,7 @@ impl StateDb {
         Ok(())
     }
 
-    pub fn refresh_for_title_id(&mut self, title_id: u64, auto_enabled: bool) -> Result<()> {
+    pub fn refresh_title(&mut self, title_id: u64, auto_enabled: bool) -> Result<()> {
         log::debug!("processing refresh for title {title_id:016X}");
 
         let mut process = |sync_item| -> Result<()> {
@@ -132,7 +132,7 @@ impl StateDb {
         Ok(())
     }
 
-    pub fn toggle_for_title_id(&mut self, title_id: u64) -> Result<()> {
+    pub fn toggle_title(&mut self, title_id: u64) -> Result<()> {
         log::debug!("toggling auto sync enabled setting for title {title_id:016X}");
 
         let states = self

--- a/cloudpoint_app/src/db/title.rs
+++ b/cloudpoint_app/src/db/title.rs
@@ -1,6 +1,6 @@
 use crate::{
     app::{RefreshProgress, UiMsg},
-    ctr_title::{self, SD_APP_TITLES},
+    ctr_title::{self, SD_APP_TITLES, get_installed_at_for_title},
 };
 use crate::{
     ctr_title::{
@@ -51,12 +51,12 @@ impl TitleDb {
         log::debug!("building runtime title db");
 
         let mut title_db = Self(root_path.as_ref().join("title.db"), HashMap::new());
-        title_db.refresh(state_db, ui_tx)?;
+        title_db.refresh_db(state_db, ui_tx)?;
 
         Ok(title_db)
     }
 
-    pub fn refresh(&mut self, state_db: &StateDb, ui_tx: &Sender<UiMsg>) -> Result<()> {
+    pub fn refresh_db(&mut self, state_db: &StateDb, ui_tx: &Sender<UiMsg>) -> Result<()> {
         log::debug!("refreshing runtime title db");
 
         let mut refresh_progress = RefreshProgress::new(ui_tx.clone());
@@ -67,7 +67,8 @@ impl TitleDb {
         let total = SD_APP_TITLES.len();
         for (i, title_id) in SD_APP_TITLES.keys().enumerate() {
             self.add_title(*title_id, state_db)?;
-            self.refresh_links(*title_id, state_db)?;
+            self.add_links_for_title(*title_id, state_db)?;
+
             refresh_progress
                 .message("Refreshing titles")
                 .progress((i + 1) * 100 / total)
@@ -102,7 +103,7 @@ impl TitleDb {
         Ok(())
     }
 
-    pub fn refresh_links(&mut self, title_id: u64, state_db: &StateDb) -> Result<()> {
+    pub fn add_links_for_title(&mut self, title_id: u64, state_db: &StateDb) -> Result<()> {
         log::info!("refreshing all links for title {title_id:016X}");
 
         let extdata_sync_item = self.1.get(&title_id).and_then(|t| t.extdata_sync_item);
@@ -112,7 +113,7 @@ impl TitleDb {
             .values_mut()
             .filter(|t| t.extdata_sync_item == extdata_sync_item)
         {
-            title.refresh(state_db);
+            title.refresh_sync_status(state_db);
         }
 
         Ok(())
@@ -124,6 +125,10 @@ impl TitleDb {
         fs::write(&self.0, postcard::to_allocvec(&self)?)?;
 
         Ok(())
+    }
+
+    pub fn title_mut(&mut self, title_id: u64) -> Option<&mut TitleDetails> {
+        self.1.get_mut(&title_id)
     }
 
     pub fn total_titles(&self) -> usize {
@@ -202,7 +207,7 @@ impl TitleDetails {
         Ok(ctr_title::smdh(self.title_id)?)
     }
 
-    pub fn refresh(&mut self, state_db: &StateDb) {
+    pub fn refresh_sync_status(&mut self, state_db: &StateDb) {
         let (sss, ess) =
             Self::sync_items_status(&self.savedata_sync_item, &self.extdata_sync_item, state_db);
 

--- a/cloudpoint_app/src/db/title.rs
+++ b/cloudpoint_app/src/db/title.rs
@@ -1,6 +1,6 @@
 use crate::{
     app::{RefreshProgress, UiMsg},
-    ctr_title::{self, SD_APP_TITLES, get_installed_at_for_title},
+    ctr_title::{self, SD_APP_TITLES},
 };
 use crate::{
     ctr_title::{
@@ -29,7 +29,7 @@ pub struct TitleDb(PathBuf, HashMap<u64, TitleDetails>);
 
 impl TitleDb {
     pub fn open(root_path: impl AsRef<Path>) -> Result<Self> {
-        log::debug!("loading runtime title db from disk");
+        log::debug!("loading title db from disk");
 
         let db_path = root_path.as_ref().join("title.db");
 
@@ -48,26 +48,32 @@ impl TitleDb {
         state_db: &StateDb,
         ui_tx: &Sender<UiMsg>,
     ) -> Result<Self> {
-        log::debug!("building runtime title db");
+        log::debug!("building title db");
 
         let mut title_db = Self(root_path.as_ref().join("title.db"), HashMap::new());
-        title_db.refresh_db(state_db, ui_tx)?;
+        title_db.add_all(state_db, ui_tx)?;
 
         Ok(title_db)
     }
 
-    pub fn refresh_db(&mut self, state_db: &StateDb, ui_tx: &Sender<UiMsg>) -> Result<()> {
-        log::debug!("refreshing runtime title db");
-
-        let mut refresh_progress = RefreshProgress::new(ui_tx.clone());
+    pub fn prune_orphaned(&mut self) -> Result<()> {
+        log::debug!("pruning orphaned title db records");
 
         let current_title_ids = SD_APP_TITLES.keys().copied().collect::<HashSet<_>>();
         self.1.retain(|k, _| current_title_ids.contains(k));
 
+        Ok(())
+    }
+
+    pub fn add_all(&mut self, state_db: &StateDb, ui_tx: &Sender<UiMsg>) -> Result<()> {
+        log::debug!("adding missing title db records");
+
+        let mut refresh_progress = RefreshProgress::new(ui_tx.clone());
         let total = SD_APP_TITLES.len();
+
         for (i, title_id) in SD_APP_TITLES.keys().enumerate() {
-            self.add_title(*title_id, state_db)?;
-            self.add_links_for_title(*title_id, state_db)?;
+            self.add_or_replace_title(*title_id, state_db)?;
+            self.refresh_shared_extdata_linked_titles(*title_id, state_db)?;
 
             refresh_progress
                 .message("Refreshing titles")
@@ -78,7 +84,7 @@ impl TitleDb {
         Ok(())
     }
 
-    fn add_title(&mut self, title_id: u64, state_db: &StateDb) -> Result<()> {
+    fn add_or_replace_title(&mut self, title_id: u64, state_db: &StateDb) -> Result<()> {
         log::debug!("processing {title_id:016X}");
 
         let Some(title) = SD_APP_TITLES.get(&title_id) else {
@@ -103,8 +109,14 @@ impl TitleDb {
         Ok(())
     }
 
-    pub fn add_links_for_title(&mut self, title_id: u64, state_db: &StateDb) -> Result<()> {
-        log::info!("refreshing all links for title {title_id:016X}");
+    pub fn refresh_shared_extdata_linked_titles(
+        &mut self,
+        title_id: u64,
+        state_db: &StateDb,
+    ) -> Result<()> {
+        log::info!(
+            "refreshing sync status for all titles which share extdata with {title_id:016X}"
+        );
 
         let extdata_sync_item = self.1.get(&title_id).and_then(|t| t.extdata_sync_item);
 
@@ -115,14 +127,6 @@ impl TitleDb {
         {
             title.refresh_sync_status(state_db);
         }
-
-        Ok(())
-    }
-
-    pub fn save(&mut self) -> Result<()> {
-        log::debug!("saving title db to disk");
-
-        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
 
         Ok(())
     }
@@ -141,6 +145,14 @@ impl TitleDb {
             .sorted_by_key(|t| t.title_short.to_lowercase())
             .cloned()
             .collect()
+    }
+
+    fn save(&mut self) -> Result<()> {
+        log::debug!("saving title db to disk");
+
+        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
+
+        Ok(())
     }
 }
 

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -4,7 +4,7 @@ use crate::{
     ctr_fs::CtrArchive,
     ctr_ndmu::KeepAwake,
     ctr_title::meta,
-    db::{InstallDb, InstallStatus},
+    db::{InstallHistoryDb, InstallStatus},
     tree::{self, CtrArchiveLeaf},
 };
 use anyhow::{Result, bail};
@@ -45,7 +45,7 @@ pub fn run<'a>(
     ui_tx: Sender<UiMsg>,
     modal_tx: Sender<OpenModalMsg>,
     client: &Rc<CurlHttpClient>,
-    install_db: &mut InstallDb,
+    install_history_db: &mut InstallHistoryDb,
 ) -> Result<()> {
     log::info!("starting sync");
 
@@ -66,7 +66,7 @@ pub fn run<'a>(
             &mut sync_progress,
             &modal_tx,
             &client,
-            install_db,
+            install_history_db,
         ) {
             Ok(_) => sync_progress.progress((i + 1) * 100 / total),
             Err(e) => {
@@ -86,7 +86,7 @@ fn run_one(
     sync_progress: &mut SyncProgress,
     modal_tx: &Sender<OpenModalMsg>,
     client: &Rc<CurlHttpClient>,
-    install_db: &mut InstallDb,
+    install_history_db: &mut InstallHistoryDb,
 ) -> Result<()> {
     log::info!("Starting sync of {}", sync_state.sync_item);
 
@@ -105,12 +105,12 @@ fn run_one(
     };
 
     for title_id in &sync_state.via_title_ids {
-        match install_db.check_install(*title_id) {
+        match install_history_db.check(*title_id) {
             InstallStatus::Updated => {
                 log::info!("via_title_id {title_id:016X}: updated tmd mtime, reset sync meta");
                 sync_state.synced_at = None;
                 sync_state.synced_fingerprint = None;
-                install_db.touch(*title_id);
+                install_history_db.touch(*title_id);
             }
             InstallStatus::Unchanged => {
                 log::debug!("via_title_id {title_id:016X}: unchanged tmd mtime, leave sync meta");
@@ -123,7 +123,13 @@ fn run_one(
         }
     }
 
-    sync_state.safe_adopt(*USER_KEY);
+    if sync_state.via_user_key != *USER_KEY {
+        log::info!("user.key has changed, adopting (new sync dialog is normal)");
+
+        sync_state.synced_at = None;
+        sync_state.synced_fingerprint = None;
+        sync_state.via_user_key = *USER_KEY;
+    }
 
     let title_label = format!(
         "{} ({})",

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -4,6 +4,7 @@ use crate::{
     ctr_fs::CtrArchive,
     ctr_ndmu::KeepAwake,
     ctr_title::meta,
+    db::{InstallDb, InstallStatus},
     tree::{self, CtrArchiveLeaf},
 };
 use anyhow::{Result, bail};
@@ -44,6 +45,7 @@ pub fn run<'a>(
     ui_tx: Sender<UiMsg>,
     modal_tx: Sender<OpenModalMsg>,
     client: &Rc<CurlHttpClient>,
+    install_db: &mut InstallDb,
 ) -> Result<()> {
     log::info!("starting sync");
 
@@ -59,7 +61,13 @@ pub fn run<'a>(
             return Ok(());
         }
 
-        match run_one(sync_state, &mut sync_progress, &modal_tx, &client) {
+        match run_one(
+            sync_state,
+            &mut sync_progress,
+            &modal_tx,
+            &client,
+            install_db,
+        ) {
             Ok(_) => sync_progress.progress((i + 1) * 100 / total),
             Err(e) => {
                 log::error!("failed mid sync: {e}");
@@ -76,8 +84,9 @@ pub fn run<'a>(
 fn run_one(
     sync_state: &mut SyncState,
     sync_progress: &mut SyncProgress,
-    alert_tx: &Sender<OpenModalMsg>,
+    modal_tx: &Sender<OpenModalMsg>,
     client: &Rc<CurlHttpClient>,
+    install_db: &mut InstallDb,
 ) -> Result<()> {
     log::info!("Starting sync of {}", sync_state.sync_item);
 
@@ -94,6 +103,25 @@ fn run_one(
 
         bail!("{} not found; was the title deleted?", sync_state.sync_item);
     };
+
+    for title_id in &sync_state.via_title_ids {
+        match install_db.check_install(*title_id) {
+            InstallStatus::Updated => {
+                log::info!("via_title_id {title_id:016X}: updated tmd mtime, reset sync meta");
+                sync_state.synced_at = None;
+                sync_state.synced_fingerprint = None;
+                install_db.touch(*title_id);
+            }
+            InstallStatus::Unchanged => {
+                log::debug!("via_title_id {title_id:016X}: unchanged tmd mtime, leave sync meta");
+            }
+            InstallStatus::Unknown => {
+                log::warn!(
+                    "via_title_id {title_id:016X}: unknown tmd mtime, probably shared extdata, leave sync meta"
+                );
+            }
+        }
+    }
 
     sync_state.safe_adopt(*USER_KEY);
 
@@ -144,7 +172,7 @@ fn run_one(
 
             let (reply_tx, reply_rx) = oneshot::channel::<ConflictWinner>();
 
-            alert_tx
+            modal_tx
                 .send(OpenModalMsg::ResolveConflict {
                     title_label: title_label.clone(),
                     title_local_time: sync_state.synced_at,

--- a/cloudpoint_lib/src/sync.rs
+++ b/cloudpoint_lib/src/sync.rs
@@ -74,16 +74,6 @@ impl SyncState {
         }
     }
 
-    pub fn safe_adopt(&mut self, user_key: Uuid) {
-        if self.via_user_key != user_key {
-            log::info!("user.key has changed, adopting (new sync dialog is normal)");
-
-            self.synced_fingerprint = None;
-            self.synced_at = None;
-            self.via_user_key = user_key;
-        }
-    }
-
     pub fn get_action(
         &self,
         local_fingerprint: Option<u128>,
@@ -232,21 +222,6 @@ mod tests {
         let res = s.get_action(Some(2), Some(2));
 
         assert!(matches!(res, SyncAction::NoChange));
-    }
-
-    #[test]
-    fn unmatched_user_key_resets_sync_state() {
-        let via_user_key = Uuid::new_v4();
-        let mut s = SyncState {
-            synced_fingerprint: Some(u128::MAX),
-            via_user_key,
-            ..fixture()
-        };
-
-        s.safe_adopt(Uuid::new_v4());
-
-        assert!(s.synced_fingerprint.is_none());
-        assert!(s.via_user_key != via_user_key);
     }
 
     fn fixture() -> SyncState {


### PR DESCRIPTION
Now uses a title's TMD file and a new install history db to track whether a title has been reinstalled. If it has, treat the sync as a fresh start which will usually lead to a conflict resolve prompt on initial sync (which you'd expect).

Note that this *doesn't* behave as expected on Azahar because it doesn't report the tmd mtime properly. It doesn't crash, but won't detect reinstalls etc. Not so much of an issue on Azahar since support is best effort anyway, and title uninstalls don't actually seem to remove the data in all cases.

This works for title reinstalls AND system formats, so removed the `device.key` feature entirely (this broke Azahar anyway so it needed to go).

Also now prunes title and state items on boot, to prevent uninstalled titles from showing (this is fast). New titles still need to be added manually with X, as before, because it can be slow.

Finally, cleaned up the code around title and state dbs because it had become too messy. I still don't love this part of the codebase but it's complex mainly due to UI wrangling, so fine.