### PR TITLE
Refresh hangs with full bar on refreshing titles with region changed systems

### DIFF
--- a/cloudpoint_app/src/app/worker.rs
+++ b/cloudpoint_app/src/app/worker.rs
@@ -18,11 +18,17 @@ pub fn worker_thread(
     modal_tx: Sender<OpenModalMsg>,
 ) -> Result<()> {
     let mut state_db = StateDb::open(AppPath::Db)
-        .or_else(|_| StateDb::new(AppPath::Db, &ui_tx))
+        .or_else(|_| {
+            modal_tx.send(OpenModalMsg::Refresh).ok();
+            StateDb::new(AppPath::Db, &ui_tx)
+        })
         .expect("state db must be available");
 
     let mut title_db = TitleDb::open(AppPath::Db)
-        .or_else(|_| TitleDb::new(AppPath::Db, &state_db, &ui_tx))
+        .or_else(|_| {
+            modal_tx.send(OpenModalMsg::Refresh).ok();
+            TitleDb::new(AppPath::Db, &state_db, &ui_tx)
+        })
         .expect("title db must be available");
 
     let mut install_history_db = InstallHistoryDb::open(AppPath::Db)
@@ -100,8 +106,6 @@ pub fn worker_thread(
                 };
             }
             Ok(TaskMsg::SyncTargeted(title_id)) => {
-                state_db.process_sync_items_for_title(title_id, false)?;
-                title_db.refresh_shared_extdata_linked_titles(title_id, &state_db)?;
                 match sync::run(
                     state_db
                         .states_mut()

--- a/cloudpoint_app/src/db/state.rs
+++ b/cloudpoint_app/src/db/state.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use anyhow::{Result, bail};
 use cloudpoint_lib::sync::{SyncItem, SyncState};
+use log::warn;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -71,7 +72,9 @@ impl StateDb {
         let total = SD_APP_TITLES.len();
 
         for (i, (&title_id, _)) in SD_APP_TITLES.iter().enumerate() {
-            self.process_sync_items_for_title(title_id, auto_enabled)?;
+            if let Err(e) = self.process_sync_items_for_title(title_id, auto_enabled) {
+                warn!("error processing sync state(s) for {title_id:016X}: {e}");
+            };
 
             refresh_progress
                 .message("Refreshing sync items")
@@ -91,6 +94,11 @@ impl StateDb {
 
         let mut process = |sync_item| -> Result<()> {
             if let Some(existing_state) = self.1.get_mut(&sync_item) {
+                if let Err(e) = CtrArchive::smdh(sync_item) {
+                    self.1.remove(&sync_item);
+                    bail!(e);
+                }
+
                 if existing_state.via_title_ids.insert(title_id) {
                     log::info!("updating {sync_item} reached via {title_id:016X}");
 

--- a/cloudpoint_app/src/db/title.rs
+++ b/cloudpoint_app/src/db/title.rs
@@ -15,6 +15,7 @@ use cloudpoint_lib::{
     sync::SyncItem,
 };
 use itertools::Itertools;
+use log::warn;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -72,8 +73,13 @@ impl TitleDb {
         let total = SD_APP_TITLES.len();
 
         for (i, title_id) in SD_APP_TITLES.keys().enumerate() {
-            self.add_or_replace_title(*title_id, state_db)?;
-            self.refresh_shared_extdata_linked_titles(*title_id, state_db)?;
+            if let Err(e) = try {
+                self.add_or_replace_title(*title_id, state_db)?;
+                self.refresh_shared_extdata_linked_titles(*title_id, state_db)?;
+            } {
+                self.remove_title(*title_id)?;
+                warn!("error processing title {title_id:016X}: {e}");
+            };
 
             refresh_progress
                 .message("Refreshing titles")
@@ -105,6 +111,12 @@ impl TitleDb {
         } else {
             log::info!("ignored {title_id:016X}, has no save or extdata");
         }
+
+        Ok(())
+    }
+
+    fn remove_title(&mut self, title_id: u64) -> Result<()> {
+        self.1.remove(&title_id);
 
         Ok(())
     }

--- a/cloudpoint_app/src/main.rs
+++ b/cloudpoint_app/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(oneshot_channel)]
+#![feature(try_blocks)]
 
 mod app;
 pub mod app_logger;

--- a/cloudpoint_app/src/screens/titles.rs
+++ b/cloudpoint_app/src/screens/titles.rs
@@ -165,6 +165,8 @@ impl BaseScreen for TitlesScreen {
 
                 return ScreenCommand::OpenModal(Box::new(SyncModalScreen::new()));
             }
+        } else if keys_down.contains(KeyPad::X) {
+            self.task_tx.send(TaskMsg::Refresh).ok();
         } else if keys_down.contains(KeyPad::Y) {
             if let Some(title) = self.selected_title() {
                 self.task_tx.send(TaskMsg::Toggle(title.title_id)).ok();

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -93,16 +93,17 @@ fn run_one(
 
     if Ac::new()?.wait_internet_connection().is_err() {
         log::warn!("internet down");
-        bail!("No internet connection");
+        bail!("No internet connection is available - please ensure you are online and try again");
     }
 
     let Ok(smdh) = CtrArchive::smdh(sync_state.sync_item) else {
-        log::info!(
-            "{} archive does not exist, cannot sync",
-            sync_state.sync_item,
-        );
+        log::warn!("{} cannot be read, cannot sync", sync_state.sync_item,);
 
-        bail!("{} not found; was the title deleted?", sync_state.sync_item);
+        bail!(
+            "{} could not be opened; was the title ({}) deleted?",
+            sync_state.sync_item,
+            sync_state.title_short
+        );
     };
 
     for title_id in &sync_state.via_title_ids {


### PR DESCRIPTION
This was a symptom of panicking when trying to inspect a title which (for whatever reason, usually missing tickets) could not be accessed. These titles are now skipped, since they're not actually going to be relevant to Cloudpoint.

Also improved cleanup of title and sync items on refresh.

Also enabled (X) to refresh from the titles screen, as well as sync. It isn't very discoverable but it just feels like a bug when it doesn't respond on this screen.

Closes #101 