### PR TITLE
Robust archive checking on discover

### DIFF
--- a/cloudpoint_app/src/app/worker.rs
+++ b/cloudpoint_app/src/app/worker.rs
@@ -55,8 +55,8 @@ pub fn worker_thread(
         match task_rx.recv() {
             Ok(TaskMsg::Refresh) => {
                 modal_tx.send(OpenModalMsg::Refresh).ok();
-                state_db.add_missing(true, &ui_tx)?;
-                title_db.add_all(&state_db, &ui_tx)?;
+                state_db.refresh(true, &ui_tx)?;
+                title_db.refresh(&state_db, &ui_tx)?;
                 ui_tx
                     .send(UiMsg::RefreshDone {
                         qty_sync_states: state_db.qty_auto(),
@@ -65,7 +65,6 @@ pub fn worker_thread(
                     .ok();
             }
             Ok(TaskMsg::Toggle(title_id)) => {
-                state_db.process_sync_items_for_title(title_id, false)?;
                 state_db.toggle_auto_sync_for_title(title_id)?;
                 title_db.refresh_shared_extdata_linked_titles(title_id, &state_db)?;
                 ui_tx

--- a/cloudpoint_app/src/ctr_fs/ffi.rs
+++ b/cloudpoint_app/src/ctr_fs/ffi.rs
@@ -6,7 +6,7 @@ use ctru_sys::{
     FSFILE_SetSize, FSFILE_Write, FSUSER_CloseArchive, FSUSER_ControlArchive,
     FSUSER_ControlSecureSave, FSUSER_CreateDirectory, FSUSER_CreateFile, FSUSER_DeleteFile,
     FSUSER_OpenArchive, FSUSER_OpenDirectory, FSUSER_OpenFile, FSUSER_OpenFileDirectly,
-    FSUSER_ReadExtSaveDataIcon, Handle, MEDIATYPE_SD, PATH_BINARY, R_FAILED,
+    FSUSER_ReadExtSaveDataIcon, Handle, MEDIATYPE_SD, PATH_BINARY, R_FAILED, R_SUCCEEDED,
     SECURESAVE_ACTION_DELETE, SECUREVALUE_SLOT_SD,
 };
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
@@ -271,12 +271,13 @@ pub(super) fn ctr_read_file(
         )
     };
 
-    // This call sometimes signals failure even though all bytes were read, so use this
-    // to determine if this call succeeded rather than checking the res code
-    if bytes_read == length as u32 {
-        Ok(length)
-    } else {
-        Err(IoError::new(
+    match (R_SUCCEEDED(res), res as u32) {
+        // Normal successful read
+        (true, _) => Ok(length),
+        // Unusual but OK read: reported as failure but with correct bytes_read value
+        (false, 0xD900458B) if bytes_read == length as u32 => Ok(length),
+        // Bad read
+        (false, _) => Err(IoError::new(
             IoErrorKind::Other,
             anyhow!(
                 "could not read bytes {} to {} via handle {:?} (read {} of {}) [{:#010X}]",
@@ -285,9 +286,9 @@ pub(super) fn ctr_read_file(
                 file_handle,
                 bytes_read,
                 length,
-                res
+                res,
             ),
-        ))
+        )),
     }
 }
 

--- a/cloudpoint_app/src/db/state.rs
+++ b/cloudpoint_app/src/db/state.rs
@@ -1,19 +1,21 @@
 use crate::{
     app::{RefreshProgress, UiMsg},
     config::USER_KEY,
-    ctr_fs::{self, CtrArchive},
+    ctr_fs::CtrArchive,
     ctr_title::{
         SD_APP_TITLES, infer_extdata_sync_item_for_title, lookup_extdata_sync_item_for_title,
+        lookup_savedata_sync_item_for_title,
     },
+    tree::{check_archive, from_archive},
 };
 use anyhow::{Result, bail};
 use cloudpoint_lib::sync::{SyncItem, SyncState};
-use log::warn;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
+    rc::Rc,
     sync::mpsc::Sender,
 };
 
@@ -42,7 +44,7 @@ impl StateDb {
         let db_path = root_path.as_ref().join("state.db");
 
         let mut state_db = Self(db_path, HashMap::new());
-        state_db.add_missing(true, ui_tx)?;
+        state_db.refresh(true, ui_tx)?;
 
         Ok(state_db)
     }
@@ -65,7 +67,7 @@ impl StateDb {
         Ok(())
     }
 
-    pub fn add_missing(&mut self, auto_enabled: bool, ui_tx: &Sender<UiMsg>) -> Result<()> {
+    pub fn refresh(&mut self, auto_enabled: bool, ui_tx: &Sender<UiMsg>) -> Result<()> {
         log::debug!("adding missing state db records");
 
         let mut refresh_progress = RefreshProgress::new(ui_tx.clone());
@@ -73,7 +75,7 @@ impl StateDb {
 
         for (i, (&title_id, _)) in SD_APP_TITLES.iter().enumerate() {
             if let Err(e) = self.process_sync_items_for_title(title_id, auto_enabled) {
-                warn!("error processing sync state(s) for {title_id:016X}: {e}");
+                log::warn!("error processing sync state(s) for {title_id:016X}: {e}");
             };
 
             refresh_progress
@@ -92,9 +94,22 @@ impl StateDb {
     ) -> Result<()> {
         log::debug!("processing refresh for title {title_id:016X}");
 
+        let probe = |sync_item| -> anyhow::Result<()> {
+            let archive = Rc::new(CtrArchive::open(sync_item)?);
+            let tree = from_archive(Rc::clone(&archive))?;
+            Ok(check_archive(&tree)?)
+        };
+
         let mut process = |sync_item| -> Result<()> {
             if let Some(existing_state) = self.1.get_mut(&sync_item) {
                 if let Err(e) = CtrArchive::smdh(sync_item) {
+                    log::info!("purging {sync_item}: smdh not accessible");
+                    self.1.remove(&sync_item);
+                    bail!(e);
+                }
+
+                if let Err(e) = probe(sync_item) {
+                    log::info!("purging {sync_item}: not readable");
                     self.1.remove(&sync_item);
                     bail!(e);
                 }
@@ -112,31 +127,39 @@ impl StateDb {
                 return Ok(());
             }
 
-            if ctr_fs::CtrArchive::open(sync_item).is_ok() {
-                log::info!("adding {sync_item} discovered via {title_id:016X}");
-
-                self.1.insert(
-                    sync_item,
-                    SyncState::new(
-                        sync_item,
-                        title_id,
-                        *USER_KEY,
-                        &CtrArchive::smdh(sync_item)?,
-                        auto_enabled,
-                    ),
-                );
+            if let Err(e) = probe(sync_item) {
+                log::info!("skipping {sync_item}: not readable");
+                bail!(e);
             }
+
+            log::info!("adding {sync_item} discovered via {title_id:016X}");
+
+            self.1.insert(
+                sync_item,
+                SyncState::new(
+                    sync_item,
+                    title_id,
+                    *USER_KEY,
+                    &CtrArchive::smdh(sync_item)?,
+                    auto_enabled,
+                ),
+            );
 
             Ok(())
         };
 
-        let sync_item = SyncItem::Savedata(title_id);
-        process(sync_item)?;
+        if let Some(sync_item) = lookup_savedata_sync_item_for_title(title_id) {
+            if let Err(e) = process(sync_item) {
+                log::warn!("{sync_item} not enabled due to error: {e}");
+            }
+        }
 
-        if let Some(sync_item) = lookup_extdata_sync_item_for_title(title_id) {
-            process(sync_item)?;
-        } else if let Some(sync_item) = infer_extdata_sync_item_for_title(title_id) {
-            process(sync_item)?;
+        if let Some(sync_item) = lookup_extdata_sync_item_for_title(title_id)
+            .or_else(|| infer_extdata_sync_item_for_title(title_id))
+        {
+            if let Err(e) = process(sync_item) {
+                log::warn!("{sync_item} not enabled due to error: {e}");
+            }
         }
 
         Ok(())

--- a/cloudpoint_app/src/db/state.rs
+++ b/cloudpoint_app/src/db/state.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     tree::{check_archive, from_archive},
 };
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use cloudpoint_lib::sync::{SyncItem, SyncState};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -20,21 +20,33 @@ use std::{
 };
 
 #[derive(Deserialize, Serialize)]
-pub struct StateDb(#[serde[skip]] PathBuf, HashMap<SyncItem, SyncState>);
+pub struct StateDb {
+    #[serde[skip]]
+    path: PathBuf,
+    header: [u8; 8],
+    data: HashMap<SyncItem, SyncState>,
+}
 
 impl StateDb {
+    const MAGIC: &[u8; 8] = b"SDB00001";
+
     pub fn open(root_path: impl AsRef<Path>) -> Result<Self> {
         log::debug!("loading state db from disk");
 
         let db_path = root_path.as_ref().join("state.db");
 
         if let Ok(buf) = fs::read(&db_path) {
-            let mut state_db = postcard::from_bytes::<StateDb>(&buf)?;
-            state_db.0 = db_path;
+            let mut state_db =
+                postcard::from_bytes::<StateDb>(&buf).context("state db cannot be loaded")?;
+            state_db.path = db_path;
+
+            if state_db.header != *Self::MAGIC {
+                bail!("state db is incompatible");
+            }
 
             Ok(state_db)
         } else {
-            bail!("state db not found")
+            bail!("state db cannot be read")
         }
     }
 
@@ -43,7 +55,11 @@ impl StateDb {
 
         let db_path = root_path.as_ref().join("state.db");
 
-        let mut state_db = Self(db_path, HashMap::new());
+        let mut state_db = Self {
+            path: db_path,
+            header: *Self::MAGIC,
+            data: HashMap::new(),
+        };
         state_db.refresh(true, ui_tx)?;
 
         Ok(state_db)
@@ -54,7 +70,7 @@ impl StateDb {
 
         let current_title_ids = SD_APP_TITLES.keys().copied().collect::<HashSet<_>>();
 
-        for state in self.1.values_mut() {
+        for state in self.data.values_mut() {
             state.via_title_ids = state
                 .via_title_ids
                 .intersection(&current_title_ids)
@@ -62,7 +78,7 @@ impl StateDb {
                 .collect();
         }
 
-        self.1.retain(|_, s| !s.via_title_ids.is_empty());
+        self.data.retain(|_, s| !s.via_title_ids.is_empty());
 
         Ok(())
     }
@@ -101,16 +117,16 @@ impl StateDb {
         };
 
         let mut process = |sync_item| -> Result<()> {
-            if let Some(existing_state) = self.1.get_mut(&sync_item) {
+            if let Some(existing_state) = self.data.get_mut(&sync_item) {
                 if let Err(e) = CtrArchive::smdh(sync_item) {
                     log::info!("purging {sync_item}: smdh not accessible");
-                    self.1.remove(&sync_item);
+                    self.data.remove(&sync_item);
                     bail!(e);
                 }
 
                 if let Err(e) = probe(sync_item) {
                     log::info!("purging {sync_item}: not readable");
-                    self.1.remove(&sync_item);
+                    self.data.remove(&sync_item);
                     bail!(e);
                 }
 
@@ -134,7 +150,7 @@ impl StateDb {
 
             log::info!("adding {sync_item} discovered via {title_id:016X}");
 
-            self.1.insert(
+            self.data.insert(
                 sync_item,
                 SyncState::new(
                     sync_item,
@@ -202,29 +218,29 @@ impl StateDb {
     }
 
     pub fn qty_total(&self) -> usize {
-        self.1.len()
+        self.data.len()
     }
 
     pub fn qty_auto(&self) -> usize {
-        self.1.iter().filter(|s| s.1.auto_enabled).count()
+        self.data.iter().filter(|s| s.1.auto_enabled).count()
     }
 
     pub fn state(&self, sync_item: &SyncItem) -> Option<&SyncState> {
-        self.1.get(sync_item)
+        self.data.get(sync_item)
     }
 
     pub fn states(&self) -> impl Iterator<Item = &SyncState> {
-        self.1.values()
+        self.data.values()
     }
 
     pub fn states_mut(&mut self) -> impl Iterator<Item = &mut SyncState> {
-        self.1.values_mut()
+        self.data.values_mut()
     }
 
     fn save(&mut self) -> Result<()> {
         log::debug!("saving state db to disk");
 
-        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
+        fs::write(&self.path, postcard::to_allocvec(&self)?)?;
 
         Ok(())
     }

--- a/cloudpoint_app/src/db/title.rs
+++ b/cloudpoint_app/src/db/title.rs
@@ -52,7 +52,7 @@ impl TitleDb {
         log::debug!("building title db");
 
         let mut title_db = Self(root_path.as_ref().join("title.db"), HashMap::new());
-        title_db.add_all(state_db, ui_tx)?;
+        title_db.refresh(state_db, ui_tx)?;
 
         Ok(title_db)
     }
@@ -66,7 +66,7 @@ impl TitleDb {
         Ok(())
     }
 
-    pub fn add_all(&mut self, state_db: &StateDb, ui_tx: &Sender<UiMsg>) -> Result<()> {
+    pub fn refresh(&mut self, state_db: &StateDb, ui_tx: &Sender<UiMsg>) -> Result<()> {
         log::debug!("adding missing title db records");
 
         let mut refresh_progress = RefreshProgress::new(ui_tx.clone());
@@ -198,8 +198,8 @@ pub enum TitleSyncStatus {
 impl Display for TitleSyncStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TitleSyncStatus::Available => unreachable!(),
             TitleSyncStatus::Unavailable => write!(f, "Not available"),
+            TitleSyncStatus::Available => unreachable!(),
             TitleSyncStatus::Enabled => write!(f, "Yes"),
             TitleSyncStatus::Disabled => write!(f, "No"),
         }
@@ -250,7 +250,7 @@ impl TitleDetails {
                     true => TitleSyncStatus::Enabled,
                     false => TitleSyncStatus::Disabled,
                 },
-                None => TitleSyncStatus::Available,
+                None => TitleSyncStatus::Unavailable,
             },
             None => TitleSyncStatus::Unavailable,
         };

--- a/cloudpoint_app/src/db/title.rs
+++ b/cloudpoint_app/src/db/title.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     db::StateDb,
 };
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use cloudpoint_lib::{
     ctr::{CtrSmdh, SmdhLanguage},
     sync::SyncItem,
@@ -26,21 +26,33 @@ use std::{
 };
 
 #[derive(Serialize, Deserialize)]
-pub struct TitleDb(PathBuf, HashMap<u64, TitleDetails>);
+pub struct TitleDb {
+    #[serde(skip)]
+    path: PathBuf,
+    header: [u8; 8],
+    data: HashMap<u64, TitleDetails>,
+}
 
 impl TitleDb {
+    const MAGIC: &[u8; 8] = b"TDB00001";
+
     pub fn open(root_path: impl AsRef<Path>) -> Result<Self> {
         log::debug!("loading title db from disk");
 
         let db_path = root_path.as_ref().join("title.db");
 
         if let Ok(buf) = fs::read(&db_path) {
-            let mut title_db = postcard::from_bytes::<TitleDb>(&buf)?;
-            title_db.0 = db_path;
+            let mut title_db =
+                postcard::from_bytes::<TitleDb>(&buf).context("title db cannot be loaded")?;
+            title_db.path = db_path;
+
+            if title_db.header != *Self::MAGIC {
+                bail!("title db is incompatible");
+            }
 
             Ok(title_db)
         } else {
-            bail!("title db not found")
+            bail!("title db cannot be read")
         }
     }
 
@@ -51,7 +63,11 @@ impl TitleDb {
     ) -> Result<Self> {
         log::debug!("building title db");
 
-        let mut title_db = Self(root_path.as_ref().join("title.db"), HashMap::new());
+        let mut title_db = Self {
+            path: root_path.as_ref().join("title.db"),
+            header: *Self::MAGIC,
+            data: HashMap::new(),
+        };
         title_db.refresh(state_db, ui_tx)?;
 
         Ok(title_db)
@@ -61,7 +77,7 @@ impl TitleDb {
         log::debug!("pruning orphaned title db records");
 
         let current_title_ids = SD_APP_TITLES.keys().copied().collect::<HashSet<_>>();
-        self.1.retain(|k, _| current_title_ids.contains(k));
+        self.data.retain(|k, _| current_title_ids.contains(k));
 
         Ok(())
     }
@@ -107,7 +123,7 @@ impl TitleDb {
             || title.extdata_sync_status != TitleSyncStatus::Unavailable
         {
             log::info!("added {title_id:016X}, has save or extdata");
-            self.1.insert(title_id, title);
+            self.data.insert(title_id, title);
         } else {
             log::info!("ignored {title_id:016X}, has no save or extdata");
         }
@@ -116,7 +132,7 @@ impl TitleDb {
     }
 
     fn remove_title(&mut self, title_id: u64) -> Result<()> {
-        self.1.remove(&title_id);
+        self.data.remove(&title_id);
 
         Ok(())
     }
@@ -130,10 +146,10 @@ impl TitleDb {
             "refreshing sync status for all titles which share extdata with {title_id:016X}"
         );
 
-        let extdata_sync_item = self.1.get(&title_id).and_then(|t| t.extdata_sync_item);
+        let extdata_sync_item = self.data.get(&title_id).and_then(|t| t.extdata_sync_item);
 
         for title in self
-            .1
+            .data
             .values_mut()
             .filter(|t| t.extdata_sync_item == extdata_sync_item)
         {
@@ -144,15 +160,15 @@ impl TitleDb {
     }
 
     pub fn title_mut(&mut self, title_id: u64) -> Option<&mut TitleDetails> {
-        self.1.get_mut(&title_id)
+        self.data.get_mut(&title_id)
     }
 
     pub fn total_titles(&self) -> usize {
-        self.1.len()
+        self.data.len()
     }
 
     pub fn titles_sorted_vec(&self) -> Vec<TitleDetails> {
-        self.1
+        self.data
             .values()
             .sorted_by_key(|t| t.title_short.to_lowercase())
             .cloned()
@@ -162,7 +178,7 @@ impl TitleDb {
     fn save(&mut self) -> Result<()> {
         log::debug!("saving title db to disk");
 
-        fs::write(&self.0, postcard::to_allocvec(&self)?)?;
+        fs::write(&self.path, postcard::to_allocvec(&self)?)?;
 
         Ok(())
     }

--- a/cloudpoint_app/src/tree.rs
+++ b/cloudpoint_app/src/tree.rs
@@ -1,6 +1,6 @@
 use crate::ctr_fs::{CtrArchive, CtrFsPath};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chunktree::tree::{Leaf, Tree, TreeError};
 use cloudpoint_lib::sync::SyncItem;
 use ctru_sys::{FS_ATTRIBUTE_DIRECTORY, FS_OPEN_READ, FS_OPEN_WRITE, FS_WRITE_FLUSH};
@@ -28,10 +28,7 @@ impl Leaf for CtrArchiveLeaf {
     fn new(path: impl AsRef<Path>, ctx: Self::Context) -> Result<Self, TreeError> {
         let path = path.as_ref().to_string_lossy().into_owned();
 
-        Ok(Self {
-            path,
-            ctx: ctx.clone(),
-        })
+        Ok(Self { path, ctx })
     }
 
     fn delete(&mut self) -> Result<(), TreeError> {
@@ -180,4 +177,17 @@ pub fn from_archive(archive: Rc<CtrArchive>) -> Result<Tree<CtrArchiveLeaf>> {
     }
 
     Ok(Tree::new(results, ctx))
+}
+
+pub fn check_archive(tree: &Tree<CtrArchiveLeaf>) -> Result<()> {
+    for leaf in tree.leaves() {
+        let path = CtrFsPath::new(&leaf.path)?;
+        let file = leaf.ctx.archive.open_file(&path, FS_OPEN_READ)?;
+        let size = file.size()?;
+        file.into_reader()?
+            .read_to_vec(0, size)
+            .with_context(|| format!("{} failed archive integrity check", leaf.path))?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
At present, if an archive can be opened it is considered OK. This isn't always true (see P&D Z if only one of the two constituent games has ever been launched); there may be others, so this feels wonky. 

This PR adds a read check when discovering archives. It does have a performance penalty equal to one full sync of all your titles, but since this isn't a common operation I think it is worth the trade.