### PR TITLE
Removes archive readability probing, recovers archive reads instead

### DIFF
--- a/cloudpoint_app/src/ctr_fs.rs
+++ b/cloudpoint_app/src/ctr_fs.rs
@@ -248,14 +248,23 @@ impl Read for CtrFileReader {
 
         let bytes_to_read = (buf.len() as u64).min(bytes_to_eof) as usize;
 
-        let n = ctr_read_file(
+        match ctr_read_file(
             self.ctr_file.file_handle,
             self.pos,
             &mut buf[..bytes_to_read],
-        )?;
-        self.pos += n;
-
-        Ok(n as usize)
+        ) {
+            Ok(n) => {
+                self.pos += n;
+                Ok(n as usize)
+            }
+            Err(e) => {
+                log::warn!(
+                    "ctr_read_file reported an error - advancing cursor and continuing anyway: {e}"
+                );
+                self.pos += bytes_to_read as u64;
+                Ok(bytes_to_read)
+            }
+        }
     }
 }
 

--- a/cloudpoint_app/src/ctr_fs/ffi.rs
+++ b/cloudpoint_app/src/ctr_fs/ffi.rs
@@ -271,24 +271,51 @@ pub(super) fn ctr_read_file(
         )
     };
 
-    match (R_SUCCEEDED(res), res as u32) {
+    match R_SUCCEEDED(res) {
         // Normal successful read
-        (true, _) => Ok(length),
+        true => {
+            log::debug!(
+                "read via handle {file_handle} at offet {offset} perfect read with correct bytes_read ({bytes_read})"
+            );
+
+            Ok(bytes_read as u64)
+        }
         // Unusual but OK read: reported as failure but with correct bytes_read value
-        (false, 0xD900458B) if bytes_read == length as u32 => Ok(length),
-        // Bad read
-        (false, _) => Err(IoError::new(
-            IoErrorKind::Other,
-            anyhow!(
-                "could not read bytes {} to {} via handle {:?} (read {} of {}) [{:#010X}]",
-                offset,
-                offset + length,
-                file_handle,
-                bytes_read,
-                length,
-                res,
-            ),
-        )),
+        false if bytes_read == length as u32 => {
+            log::debug!(
+                "read via handle {file_handle} as offset {offset} recovered read with correct bytes_read ({bytes_read})"
+            );
+
+            Ok(bytes_read as u64)
+        }
+        // Bad read: zero fill up to the reqested len
+        false if bytes_read < length as u32 => {
+            log::warn!(
+                "read via handle {file_handle} at offset {offset} truncated read with short bytes_read ({bytes_read}/{length}) - zero filling to end",
+            );
+            buf[bytes_read as usize..].fill(0x00);
+
+            Err(IoError::new(
+                IoErrorKind::Other,
+                anyhow!("truncated read ({}/{}) [{:#010X}]", bytes_read, length, res,),
+            ))
+        }
+        // Bad read: this is probably an uninitialised archive
+        false => {
+            log::warn!(
+                "read via handle {file_handle} at offset {offset} error read with long (garbage) bytes_read ({bytes_read}/{length})",
+            );
+
+            Err(IoError::new(
+                IoErrorKind::Other,
+                anyhow!(
+                    "impossible read ({}/{}) [{:#010X}]",
+                    bytes_read,
+                    length,
+                    res,
+                ),
+            ))
+        }
     }
 }
 

--- a/cloudpoint_app/src/db/state.rs
+++ b/cloudpoint_app/src/db/state.rs
@@ -6,7 +6,6 @@ use crate::{
         SD_APP_TITLES, infer_extdata_sync_item_for_title, lookup_extdata_sync_item_for_title,
         lookup_savedata_sync_item_for_title,
     },
-    tree::{check_archive, from_archive},
 };
 use anyhow::{Result, bail};
 use cloudpoint_lib::sync::{SyncItem, SyncState};
@@ -15,7 +14,6 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
-    rc::Rc,
     sync::mpsc::Sender,
 };
 
@@ -94,22 +92,10 @@ impl StateDb {
     ) -> Result<()> {
         log::debug!("processing refresh for title {title_id:016X}");
 
-        let probe = |sync_item| -> anyhow::Result<()> {
-            let archive = Rc::new(CtrArchive::open(sync_item)?);
-            let tree = from_archive(Rc::clone(&archive))?;
-            Ok(check_archive(&tree)?)
-        };
-
         let mut process = |sync_item| -> Result<()> {
             if let Some(existing_state) = self.1.get_mut(&sync_item) {
                 if let Err(e) = CtrArchive::smdh(sync_item) {
                     log::info!("purging {sync_item}: smdh not accessible");
-                    self.1.remove(&sync_item);
-                    bail!(e);
-                }
-
-                if let Err(e) = probe(sync_item) {
-                    log::info!("purging {sync_item}: not readable");
                     self.1.remove(&sync_item);
                     bail!(e);
                 }
@@ -125,11 +111,6 @@ impl StateDb {
                 }
 
                 return Ok(());
-            }
-
-            if let Err(e) = probe(sync_item) {
-                log::info!("skipping {sync_item}: not readable");
-                bail!(e);
             }
 
             log::info!("adding {sync_item} discovered via {title_id:016X}");

--- a/cloudpoint_app/src/tree.rs
+++ b/cloudpoint_app/src/tree.rs
@@ -1,6 +1,6 @@
 use crate::ctr_fs::{CtrArchive, CtrFsPath};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use chunktree::tree::{Leaf, Tree, TreeError};
 use cloudpoint_lib::sync::SyncItem;
 use ctru_sys::{FS_ATTRIBUTE_DIRECTORY, FS_OPEN_READ, FS_OPEN_WRITE, FS_WRITE_FLUSH};
@@ -177,17 +177,4 @@ pub fn from_archive(archive: Rc<CtrArchive>) -> Result<Tree<CtrArchiveLeaf>> {
     }
 
     Ok(Tree::new(results, ctx))
-}
-
-pub fn check_archive(tree: &Tree<CtrArchiveLeaf>) -> Result<()> {
-    for leaf in tree.leaves() {
-        let path = CtrFsPath::new(&leaf.path)?;
-        let file = leaf.ctx.archive.open_file(&path, FS_OPEN_READ)?;
-        let size = file.size()?;
-        file.into_reader()?
-            .read_to_vec(0, size)
-            .with_context(|| format!("{} failed archive integrity check", leaf.path))?;
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
Opted for a more tolerant approach. Vast majority of reads are 100% OK, for the ones which aren't, power through since they're probably just uninitialised.

This is the approach Checkpoint takes and I think it is a reasonable one.