### PR TITLE
Chunktree store impl does not check http responses

### DIFF
--- a/cloudpoint_lib/src/http.rs
+++ b/cloudpoint_lib/src/http.rs
@@ -6,11 +6,10 @@
 /// wrapper around it.
 ///
 /// Requires 3ds-zlib, 3ds-mbedtls, 3ds-curl be installed on the host system.
-use anyhow::{Result, bail};
 use curl_sys::*;
 use libc::c_void;
 use std::ffi::{CStr, CString};
-use std::ptr;
+use std::{io::Error as IoError, ptr};
 
 #[derive(Debug)]
 pub struct Response {
@@ -26,7 +25,7 @@ pub struct CurlHttpClient {
 // Single-threaded CTR homebrew only.
 unsafe impl Send for CurlHttpClient {}
 
-fn check(code: CURLcode) -> Result<()> {
+fn check(code: CURLcode) -> Result<(), IoError> {
     if code == CURLE_OK {
         Ok(())
     } else {
@@ -35,15 +34,15 @@ fn check(code: CURLcode) -> Result<()> {
             CStr::from_ptr(raw_msg).to_string_lossy()
         };
 
-        bail!("libcurl error {code}: {msg}")
+        Err(IoError::other(format!("libcurl error {code}: {msg}")))
     }
 }
 
 impl CurlHttpClient {
-    pub fn new(app_ver: &str) -> Result<Self> {
+    pub fn new(app_ver: &str) -> Result<Self, IoError> {
         let handle = unsafe { curl_easy_init() };
         if handle.is_null() {
-            bail!("libcurl error: curl_easy_init failed")
+            return Err(IoError::other("libcurl curl_easy_init failed"));
         }
 
         // Options that never change across requests.
@@ -75,15 +74,15 @@ impl CurlHttpClient {
         Ok(Self { handle })
     }
 
-    fn set_long(&self, opt: CURLoption, val: libc::c_long) -> Result<()> {
+    fn set_long(&self, opt: CURLoption, val: libc::c_long) -> Result<(), IoError> {
         check(unsafe { curl_easy_setopt(self.handle, opt, val) })
     }
 
-    fn set_ptr(&self, opt: CURLoption, val: *const c_void) -> Result<()> {
+    fn set_ptr(&self, opt: CURLoption, val: *const c_void) -> Result<(), IoError> {
         check(unsafe { curl_easy_setopt(self.handle, opt, val) })
     }
 
-    fn set_off_t(&self, opt: CURLoption, val: curl_off_t) -> Result<()> {
+    fn set_off_t(&self, opt: CURLoption, val: curl_off_t) -> Result<(), IoError> {
         check(unsafe { curl_easy_setopt(self.handle, opt, val) })
     }
 
@@ -94,7 +93,7 @@ impl CurlHttpClient {
         code as u32
     }
 
-    fn reset_request(&self) -> Result<()> {
+    fn reset_request(&self) -> Result<(), IoError> {
         self.set_long(CURLOPT_HTTPGET, 0)?;
         self.set_long(CURLOPT_NOBODY, 0)?;
         self.set_long(CURLOPT_UPLOAD, 0)?;
@@ -108,7 +107,7 @@ impl CurlHttpClient {
         Ok(())
     }
 
-    fn build_headers(&self, extra: &[(&str, &str)]) -> Result<Slist> {
+    fn build_headers(&self, extra: &[(&str, &str)]) -> Result<Slist, IoError> {
         let mut slist = Slist::new();
 
         for (k, v) in extra {
@@ -118,7 +117,7 @@ impl CurlHttpClient {
         Ok(slist)
     }
 
-    fn perform(&self, headers: &mut Vec<String>, body: &mut Vec<u8>) -> Result<()> {
+    fn perform(&self, headers: &mut Vec<String>, body: &mut Vec<u8>) -> Result<(), IoError> {
         self.set_ptr(CURLOPT_WRITEDATA, body as *mut Vec<u8> as *mut c_void)?;
         self.set_ptr(
             CURLOPT_HEADERDATA,
@@ -127,7 +126,7 @@ impl CurlHttpClient {
         check(unsafe { curl_easy_perform(self.handle) })
     }
 
-    pub fn get(&self, url: &str, headers: &[(&str, &str)]) -> Result<Response> {
+    pub fn get(&self, url: &str, headers: &[(&str, &str)]) -> Result<Response, IoError> {
         log::debug!("performing libcurl GET to {url}");
 
         self.reset_request()?;
@@ -150,7 +149,7 @@ impl CurlHttpClient {
         })
     }
 
-    pub fn head(&self, url: &str, headers: &[(&str, &str)]) -> Result<Response> {
+    pub fn head(&self, url: &str, headers: &[(&str, &str)]) -> Result<Response, IoError> {
         log::debug!("performing libcurl HEAD to {url}");
 
         self.reset_request()?;
@@ -175,7 +174,12 @@ impl CurlHttpClient {
         })
     }
 
-    pub fn put(&self, url: &str, data: &[u8], headers: &[(&str, &str)]) -> Result<Response> {
+    pub fn put(
+        &self,
+        url: &str,
+        data: &[u8],
+        headers: &[(&str, &str)],
+    ) -> Result<Response, IoError> {
         log::debug!("performing libcurl PUT to {url}");
 
         self.reset_request()?;
@@ -222,11 +226,11 @@ impl Slist {
         Self(ptr::null_mut())
     }
 
-    fn append(&mut self, s: &str) -> Result<()> {
+    fn append(&mut self, s: &str) -> Result<(), IoError> {
         let cs = CString::new(s)?;
         let next = unsafe { curl_slist_append(self.0, cs.as_ptr()) };
         if next.is_null() {
-            bail!("libcurl error: curl_slist_append failed")
+            Err(IoError::other("libcurl curl_slist_append failed"))
         } else {
             self.0 = next;
             Ok(())

--- a/cloudpoint_lib/src/store.rs
+++ b/cloudpoint_lib/src/store.rs
@@ -59,7 +59,21 @@ impl StoreRead for HttpStore {
         let res = self
             .http_client
             .get(&self.fq_hash_url(hash), &[])
-            .map_err(|err| io::Error::other(format!("failed to get chunk {hash:032x}, {err}")))?;
+            .map_err(|err| {
+                io::Error::other(format!("transport failure for chunk {hash:032x}, {err}"))
+            })?;
+
+        match res.status {
+            200 => log::debug!("completed download for chunk {hash:032x}"),
+            _ => {
+                return Err(io::Error::other(format!(
+                    "server rejected get for chunk {hash:032x}, {} (HTTP {})",
+                    String::from_utf8_lossy(&res.body),
+                    res.status,
+                ))
+                .into());
+            }
+        }
 
         log::debug!("adding chunk {hash:032x} to lru cache");
         lru.put(hash, res.body.clone());
@@ -219,6 +233,23 @@ mod tests {
 
         get_mock.assert();
         assert_eq!(buf, b"test data");
+    }
+
+    #[test]
+    fn missing_get_chunk_causes_error() {
+        let srv = MockServer::start();
+        let get_mock = srv.mock(|when, then| {
+            when.method("GET");
+            then.status(404);
+        });
+
+        let client = CurlHttpClient::new("0.0.0").unwrap();
+        let store = super::HttpStore::new(Rc::new(client), srv.base_url(), Uuid::new_v4());
+
+        let res = store.get_chunk(0x00);
+
+        get_mock.assert();
+        assert!(res.is_err());
     }
 
     #[test]

--- a/cloudpoint_lib/src/store.rs
+++ b/cloudpoint_lib/src/store.rs
@@ -1,5 +1,4 @@
 use crate::http::CurlHttpClient;
-use anyhow::anyhow;
 use chunktree::store::{StoreError, StoreRead, StoreWrite};
 use flate2::{
     Compression,
@@ -60,12 +59,7 @@ impl StoreRead for HttpStore {
         let res = self
             .http_client
             .get(&self.fq_hash_url(hash), &[])
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    anyhow!("failed to get chunk {hash:032x}, {err}"),
-                )
-            })?;
+            .map_err(|err| io::Error::other(format!("failed to get chunk {hash:032x}, {err}")))?;
 
         log::debug!("adding chunk {hash:032x} to lru cache");
         lru.put(hash, res.body.clone());
@@ -100,10 +94,9 @@ impl StoreWrite for HttpStore {
             .http_client
             .head(&url, &[])
             .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    anyhow!("failed to check existence of chunk {hash:032x}, {err}"),
-                )
+                io::Error::other(format!(
+                    "failed to check existence of chunk {hash:032x}, {err}"
+                ))
             })?
             .status
             == 204;
@@ -115,12 +108,21 @@ impl StoreWrite for HttpStore {
             let mut gzip_encoder = GzEncoder::new(data, Compression::best());
             gzip_encoder.read_to_end(&mut body)?;
 
-            self.http_client.put(&url, &body, &[]).map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    anyhow!("failed to put chunk {hash:032x}, {err}"),
-                )
+            let res = self.http_client.put(&url, &body, &[]).map_err(|err| {
+                io::Error::other(format!("transport failure for chunk {hash:032x}, {err}"))
             })?;
+
+            match res.status {
+                201 => log::debug!("completed upload for chunk {hash:032x}"),
+                _ => {
+                    return Err(io::Error::other(format!(
+                        "server rejected put for chunk {hash:032x}, {} (HTTP {})",
+                        String::from_utf8_lossy(&res.body),
+                        res.status,
+                    ))
+                    .into());
+                }
+            }
         } else {
             log::debug!("skipped upload for hash {hash:032x}, already exists")
         }
@@ -150,7 +152,7 @@ mod tests {
         });
         let put_mock = srv.mock(|when, then| {
             when.method("PUT");
-            then.status(200);
+            then.status(201);
         });
 
         let client = CurlHttpClient::new("0.0.0").unwrap();
@@ -159,10 +161,36 @@ mod tests {
         let hash = 123;
         let data =
             b"test data, we will not gzip it for test brevity since we won't bother unzipping it";
-        store.put_chunk(hash, &mut Cursor::new(data)).unwrap();
+        let res = store.put_chunk(hash, &mut Cursor::new(data));
 
         head_mock.assert();
         put_mock.assert();
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn failing_put_chunk_causes_error() {
+        let srv = MockServer::start();
+        let head_mock = srv.mock(|when, then| {
+            when.method("HEAD");
+            then.status(204);
+        });
+        let put_mock = srv.mock(|when, then| {
+            when.method("PUT");
+            then.status(400);
+        });
+
+        let client = CurlHttpClient::new("0.0.0").unwrap();
+        let mut store = super::HttpStore::new(Rc::new(client), srv.base_url(), Uuid::new_v4());
+
+        let hash = 123;
+        let data =
+            b"test data, we will not gzip it for test brevity since we won't bother unzipping it";
+        let res = store.put_chunk(hash, &mut Cursor::new(data));
+
+        head_mock.assert();
+        put_mock.assert();
+        assert!(res.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Improve resilience by actually checking HTTP response codes - we had a few orphan chunks (fewer than 10 across 100,000 chunks) caused by this.