### PR TITLE
Do not sync abort when title meta versions do not match (unreliable signal)

### DIFF
--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -346,14 +346,8 @@ fn dl(
     )?;
 
     if local_meta.required_version() != remote_ver.meta().required_version() {
-        log::info!(
-            "title versions do not match, cannot sync: local={:?} remote={:?}",
-            local_meta.required_version(),
-            remote_ver.meta().required_version()
-        );
-
-        bail!(
-            "Title version mismatch: local={:?} remote={:?} (ensure you are running the latest version on all consoles and try again)",
+        log::warn!(
+            "title versions do not match, but sync will attempt to continue: local={:?} remote={:?}",
             local_meta.required_version(),
             remote_ver.meta().required_version()
         );


### PR DESCRIPTION
Closes #131 

Use of the title version metadata is very unreliable. Most titles don't seem to use it anyway, and it looks like Azahar doesn't report it properly so creates sync issues.

Upgraded the log note to warn, but allows sync to continue now. 