### PR TITLE
Install history db does not correctly handle title with savedata and extdata

### DIFF
--- a/cloudpoint_app/src/db/install_history.rs
+++ b/cloudpoint_app/src/db/install_history.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use cloudpoint_lib::sync::SyncItem;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -9,7 +10,7 @@ use std::{
 use crate::ctr_title::get_installed_at_for_title;
 
 #[derive(Deserialize, Serialize)]
-pub struct InstallHistoryDb(#[serde[skip]] PathBuf, HashMap<u64, u64>);
+pub struct InstallHistoryDb(#[serde[skip]] PathBuf, HashMap<(u64, SyncItem), u64>);
 
 impl InstallHistoryDb {
     pub fn open(root_path: impl AsRef<Path>) -> Result<Self> {
@@ -36,9 +37,9 @@ impl InstallHistoryDb {
         Ok(install_db)
     }
 
-    pub fn check(&self, title_id: u64) -> InstallStatus {
+    pub fn check(&self, title_id: u64, sync_item: SyncItem) -> InstallStatus {
         let latest_mtime = &get_installed_at_for_title(title_id);
-        let cached_mtime = self.1.get(&title_id);
+        let cached_mtime = self.1.get(&(title_id, sync_item));
 
         log::debug!("latest_mtime is {:?}", latest_mtime);
         log::debug!("cached_mtime is {:?}", cached_mtime);
@@ -51,9 +52,9 @@ impl InstallHistoryDb {
         }
     }
 
-    pub fn touch(&mut self, title_id: u64) {
+    pub fn touch(&mut self, title_id: u64, sync_item: SyncItem) {
         self.1.insert(
-            title_id,
+            (title_id, sync_item),
             get_installed_at_for_title(title_id)
                 .expect("install mtime should be available for title"),
         );

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -214,7 +214,7 @@ fn run_one(
     log::debug!("Remote: {:032x}", remote_fingerprint.unwrap_or_default());
 
     match sync_state.get_action(local_fingerprint, remote_fingerprint) {
-        SyncAction::NoChange | SyncAction::NoChangeOnInit => {
+        SyncAction::NoChange => {
             log::info!("local and remote data match for {}", sync_state.sync_item,);
 
             if sync_state.synced_fingerprint.is_none() {
@@ -223,7 +223,7 @@ fn run_one(
 
             sync_state.synced_at = Some(Utc::now());
         }
-        SyncAction::Conflict | SyncAction::ConflictOnInit => {
+        SyncAction::Conflict => {
             log::info!("changed on server and locally for {}", sync_state.sync_item,);
 
             let (reply_tx, reply_rx) = oneshot::channel::<ConflictWinner>();

--- a/cloudpoint_app/src/sync.rs
+++ b/cloudpoint_app/src/sync.rs
@@ -155,12 +155,12 @@ fn run_one(
     }
 
     for title_id in &sync_state.via_title_ids {
-        match install_history_db.check(*title_id) {
+        match install_history_db.check(*title_id, sync_state.sync_item) {
             InstallStatus::Updated => {
                 log::info!("via_title_id {title_id:016X}: updated tmd mtime, reset sync meta");
                 sync_state.synced_at = None;
                 sync_state.synced_fingerprint = None;
-                install_history_db.touch(*title_id);
+                install_history_db.touch(*title_id, sync_state.sync_item);
             }
             InstallStatus::Unchanged => {
                 log::debug!("via_title_id {title_id:016X}: unchanged tmd mtime, leave sync meta");

--- a/cloudpoint_lib/src/sync.rs
+++ b/cloudpoint_lib/src/sync.rs
@@ -112,9 +112,7 @@ impl SyncState {
 #[derive(Debug, Eq, PartialEq)]
 pub enum SyncAction {
     NoChange,
-    NoChangeOnInit,
     Conflict,
-    ConflictOnInit,
     Upload,
     Download,
 }


### PR DESCRIPTION
Expands the install history DB to correctly consider both the title AND the specific item being synced. This prevents an earlier decision clobbering the need to also decide whether to upload or download for a later one. 

This is relevant for title which use both save and extdata. It shouldn't make things more noisy for shared extdata titles since for subsequent checks the fingerprints will match anyway.